### PR TITLE
Add rake task to update FEC links

### DIFF
--- a/lib/fec_links.rb
+++ b/lib/fec_links.rb
@@ -1,0 +1,12 @@
+class FecLinks
+  def self.update
+    Reference.where("source like 'http://query.nictusa.com/%'").find_each do |ref|
+      ref.source = ref.source.gsub("http://query.nictusa.com/", "http://docquery.fec.gov/")
+      ref.save!
+    end
+  end
+
+  def self.verify
+    puts "There are " + Reference.where("source like 'http://query.nictusa.com/%'").count.to_s + " reference links with 'query.nictusa.com'"
+  end
+end

--- a/lib/tasks/fec.rake
+++ b/lib/tasks/fec.rake
@@ -1,0 +1,12 @@
+namespace :fec do
+  desc "Fixes the fec links"
+  task update: :environment do
+    FecLinks.update
+  end
+
+  desc "Reports how many fec links contain the problematic url"
+  task verify: :environment do
+    FecLinks.verify
+  end
+
+end

--- a/spec/lib/fec_links_spec.rb
+++ b/spec/lib/fec_links_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'FecLinks' do
+
+  before(:all) do
+    l = create(:list)
+    @ref1 = create(:ref, source: "http://query.nictusa.com/link1", object_id: l.id)
+    @ref2 = create(:ref, source: "http://query.nictusa.com/link2", object_id: l.id)
+    @ref3 = create(:ref, source: "http://cats.net/cat", object_id: l.id)
+    FecLinks.update
+  end
+
+  it 'replaces query.nictusa.com with docquery.fec.gov' do
+    expect(Reference.where("source like 'http://query.nictusa.com/%'").count).to eq(0)
+    expect(Reference.where("source like 'http://docquery.fec.gov/%'").count).to eq(2)
+  end
+
+  it 'updates links correctly' do
+    expect(Reference.find(@ref1.id).source).to eql("http://docquery.fec.gov/link1")
+    expect(Reference.find(@ref2.id).source).to eql("http://docquery.fec.gov/link2")
+  end
+
+  it 'does not change other records' do
+    expect(Reference.find(@ref3.id).source).to eql("http://cats.net/cat")
+  end
+
+end


### PR DESCRIPTION
Updates all reference links that start with "http://query.nictusa.com/" &
replaces them with "http://docquery.fec.gov/"

Two rake tasks: fec:update & fec:verify

Fixes https://github.com/littlesis-org/littlesis/issues/17
