### PR TITLE
Lists modifications page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ gem 'rmagick'
 
 gem 'capybara'
 gem 'capybara-webkit'
-gem 'paper_trail', '~> 4.0.0.beta2'
+gem 'paper_trail', '>= 5.1.1'
 gem 'foreigner'
 gem 'validate_url'
 gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,10 +192,10 @@ GEM
     nokogiri (1.5.11)
     ntlm-http (0.1.1)
     orm_adapter (0.5.0)
-    paper_trail (4.0.0.rc1)
+    paper_trail (5.2.0)
       activerecord (>= 3.0, < 6.0)
       activesupport (>= 3.0, < 6.0)
-      request_store (~> 1.1.0)
+      request_store (~> 1.1)
     php-serialize (1.1.0)
     poltergeist (1.6.0)
       capybara (~> 2.1)
@@ -250,7 +250,7 @@ GEM
     redis-store (1.1.4)
       redis (>= 2.2)
     remotipart (1.2.1)
-    request_store (1.1.0)
+    request_store (1.3.1)
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
     riddle (1.5.11)
@@ -397,7 +397,7 @@ DEPENDENCIES
   mini_magick
   mysql2
   nilify_blanks
-  paper_trail (~> 4.0.0.beta2)
+  paper_trail (>= 5.1.1)
   php-serialize
   poltergeist
   pry

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -2,6 +2,7 @@ class ListsController < ApplicationController
   before_filter :auth, except: [:index, :relationships, :members, :clear_cache, :interlocks, :companies, :government, :other_orgs, :references, :giving, :funding]
   before_action :set_list, only: [:show, :edit, :update, :destroy, :relationships, :match_donations, :search_data, :admin, :find_articles, :crop_images, :street_views, :members, :create_map, :update_entity, :remove_entity, :clear_cache, :add_entity, :find_entity, :delete, :interlocks, :companies, :government, :other_orgs, :references, :giving, :funding, :modifications]
 
+  helper_method :version_changes
 
   def self.get_lists(page)
     List
@@ -239,8 +240,26 @@ class ListsController < ApplicationController
   end
 
   def modifications
+    @versions = Kaminari.paginate_array(@list.versions.reverse).page(params[:page])
   end
   
+  def version_changes(changeset)
+    changes = ""
+    changeset.each_pair do |key, value| 
+      changes += "<strong>#{key}:</strong> #{self.class.nil_string(value[0])} -> #{self.class.nil_string(value[1])}"
+      changes += "<br>"
+    end
+    changes.html_safe
+  end
+  
+  def self.nil_string(maybe_nil)
+    if maybe_nil.nil?
+      return "nil"
+    else
+      return maybe_nil
+    end
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_list

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,6 +1,6 @@
 class ListsController < ApplicationController
   before_filter :auth, except: [:index, :relationships, :members, :clear_cache, :interlocks, :companies, :government, :other_orgs, :references, :giving, :funding]
-  before_action :set_list, only: [:show, :edit, :update, :destroy, :relationships, :match_donations, :search_data, :admin, :find_articles, :crop_images, :street_views, :members, :create_map, :update_entity, :remove_entity, :clear_cache, :add_entity, :find_entity, :delete, :interlocks, :companies, :government, :other_orgs, :references, :giving, :funding]
+  before_action :set_list, only: [:show, :edit, :update, :destroy, :relationships, :match_donations, :search_data, :admin, :find_articles, :crop_images, :street_views, :members, :create_map, :update_entity, :remove_entity, :clear_cache, :add_entity, :find_entity, :delete, :interlocks, :companies, :government, :other_orgs, :references, :giving, :funding, :modifications]
 
 
   def self.get_lists(page)
@@ -238,6 +238,9 @@ class ListsController < ApplicationController
     )  
   end
 
+  def modifications
+  end
+  
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_list
@@ -252,7 +255,7 @@ class ListsController < ApplicationController
     def interlocks_results(options)
       @page = params.fetch(:page, 1)
       num = params.fetch(:num, 20)
-      results = @list.interlocks(options).page(@page).per(num)
+      results = @list     .interlocks(options).page(@page).per(num)
       count = @list.interlocks_count(options)
       Kaminari.paginate_array(results.to_a, total_count: count).page(@page).per(num)
     end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -240,7 +240,7 @@ class ListsController < ApplicationController
   end
 
   def modifications
-    @versions = Kaminari.paginate_array(@list.versions.reverse).page(params[:page])
+    @versions = Kaminari.paginate_array(@list.versions.reverse).page(params[:page]).per(5)
   end
   
   def version_changes(changeset)

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -241,6 +241,7 @@ class ListsController < ApplicationController
 
   def modifications
     @versions = Kaminari.paginate_array(@list.versions.reverse).page(params[:page]).per(5)
+    @all_entities = ListEntity.unscoped.where(list_id: @list.id).order(id: :desc).page(params[:page]).per(10)
   end
   
 

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -2,7 +2,7 @@ class ListsController < ApplicationController
   before_filter :auth, except: [:index, :relationships, :members, :clear_cache, :interlocks, :companies, :government, :other_orgs, :references, :giving, :funding]
   before_action :set_list, only: [:show, :edit, :update, :destroy, :relationships, :match_donations, :search_data, :admin, :find_articles, :crop_images, :street_views, :members, :create_map, :update_entity, :remove_entity, :clear_cache, :add_entity, :find_entity, :delete, :interlocks, :companies, :government, :other_orgs, :references, :giving, :funding, :modifications]
 
-  helper_method :version_changes
+  
 
   def self.get_lists(page)
     List
@@ -243,22 +243,6 @@ class ListsController < ApplicationController
     @versions = Kaminari.paginate_array(@list.versions.reverse).page(params[:page]).per(5)
   end
   
-  def version_changes(changeset)
-    changes = ""
-    changeset.each_pair do |key, value| 
-      changes += "<strong>#{key}:</strong> #{self.class.nil_string(value[0])} -> #{self.class.nil_string(value[1])}"
-      changes += "<br>"
-    end
-    changes.html_safe
-  end
-  
-  def self.nil_string(maybe_nil)
-    if maybe_nil.nil?
-      return "nil"
-    else
-      return maybe_nil
-    end
-  end
 
   private
     # Use callbacks to share common setup or constraints between actions.

--- a/app/helpers/lists_helper.rb
+++ b/app/helpers/lists_helper.rb
@@ -1,10 +1,27 @@
 module ListsHelper
-	def list_link(list, name=nil)
-		name ||= list.name
-		link_to(name, members_list_path(list))
-	end
+  def list_link(list, name=nil)
+    name ||= list.name
+    link_to(name, members_list_path(list))
+  end
 
-	def network_link(list)
-		link_to(list.name, list.legacy_network_url)
-	end
+  def network_link(list)
+    link_to(list.name, list.legacy_network_url)
+  end
+
+  def version_changes(changeset)
+    changes = ""
+    changeset.each_pair do |key, value| 
+      changes += "<strong>#{key}:</strong> #{nil_string(value[0])} -> #{nil_string(value[1])}"
+      changes += "<br>"
+    end
+    changes.html_safe
+  end
+
+  def nil_string(maybe_nil)
+    if maybe_nil.nil?
+      return "nil"
+    else
+      return maybe_nil
+    end
+  end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -5,6 +5,8 @@ class List < ActiveRecord::Base
   include Cacheable
   include Referenceable
 
+  has_paper_trail
+  
   has_many :list_entities, inverse_of: :list, dependent: :destroy
   has_many :entities, through: :list_entities
   has_many :images, through: :entities
@@ -31,6 +33,10 @@ class List < ActiveRecord::Base
 
   validates_presence_of :name
 
+  def destroy
+    soft_delete
+  end
+  
   def to_param
     "#{id}-#{name.parameterize}"
   end

--- a/app/models/list_entity.rb
+++ b/app/models/list_entity.rb
@@ -5,4 +5,9 @@ class ListEntity < ActiveRecord::Base
 
   belongs_to :list, inverse_of: :list_entities
   belongs_to :entity, inverse_of: :list_entities
+
+  def destroy
+    soft_delete
+  end
+
 end

--- a/app/views/lists/_entity_row.html.erb
+++ b/app/views/lists/_entity_row.html.erb
@@ -1,0 +1,15 @@
+<% if entity.is_deleted %>
+    <tr>
+        <td><%=  entity.updated_at  %></td>
+        <td>DELETE</td>
+        <td><%=  entity.entity.name %></td>
+    </tr>
+<% end %>
+
+<tr>
+    <td><%=  entity.created_at  %></td>
+    <td>ADD</td>
+    <td><%=  entity.entity.name %></td>
+</tr>
+
+

--- a/app/views/lists/_tabs.html.erb
+++ b/app/views/lists/_tabs.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <script>
-document.ready(function() {
+ $(document).ready(function() {
   $('.list_tabs').bettertabs();
 })
 </script>

--- a/app/views/lists/_tabs.html.erb
+++ b/app/views/lists/_tabs.html.erb
@@ -8,7 +8,7 @@
     <% end %>
   <% end %>
   <%= tab.link :sources, url: references_list_path %>
-  <%= tab.link :edits, url: list.legacy_url('modifications') %>
+  <%= tab.link :edits, url: modifications_list_path(list) %>
 <% end %>
 
 <script>

--- a/app/views/lists/_tabs.html.erb
+++ b/app/views/lists/_tabs.html.erb
@@ -7,7 +7,7 @@
       <%= tab.link :funding, url: funding_list_path(list) %>
     <% end %>
   <% end %>
-  <%= tab.link :sources, url: references_list_path %>
+  <%= tab.link :sources, url: references_list_path(list) %>
   <%= tab.link :edits, url: modifications_list_path(list) %>
 <% end %>
 

--- a/app/views/lists/modifications.html.erb
+++ b/app/views/lists/modifications.html.erb
@@ -3,7 +3,7 @@
 <%= render partial: 'header', locals: { list: @list } %>
 <%= render partial: "lists/tabs", locals: { list: @list, selected_tab: :edits } %>
 
-<h1>Recent edits:</h1>
+<h2>Recent edits:</h2>
 
 <%= paginate @versions %>
 
@@ -23,3 +23,20 @@
         <% end %>
     </tbody>
 </table>
+
+<h2>Additions and deletions:</h2>
+<%= paginate @all_entities %>
+
+<table class="table">
+    <thead>
+        <th>Date</th>
+        <th>Add/Delete</th>
+        <th>Name</th>
+    </thead>
+    <tbody>
+        <% @all_entities.each do |entity| %>
+            <%= render partial: "entity_row", locals: {entity: entity} %>
+        <% end %>
+    </tbody>
+</table>
+

--- a/app/views/lists/modifications.html.erb
+++ b/app/views/lists/modifications.html.erb
@@ -1,0 +1,6 @@
+<% content_for(:page_title, raw(@list.name)) %>
+
+<%= render partial: 'header', locals: { list: @list } %>
+<%= render partial: "lists/tabs", locals: { list: @list, selected_tab: :edits } %>
+
+<h1>edits page here</h1>

--- a/app/views/lists/modifications.html.erb
+++ b/app/views/lists/modifications.html.erb
@@ -3,4 +3,23 @@
 <%= render partial: 'header', locals: { list: @list } %>
 <%= render partial: "lists/tabs", locals: { list: @list, selected_tab: :edits } %>
 
-<h1>edits page here</h1>
+<h1>Recent edits:</h1>
+
+<%= paginate @versions %>
+
+<table class="table">
+    <thead>
+        <th>Date</th>
+        <th>Type</th>
+        <th>Details</th>
+    </thead>
+    <tbody>
+        <% @versions.each do |ver| %>
+            <tr>
+                <td><%=  ver.created_at %></td>
+                <td><%=  ver.event %></td>
+                <td><%=  version_changes(ver.changeset) %></td>
+            </tr>
+        <% end %>
+    </tbody>
+</table>

--- a/app/views/shared/_bootstrap_nav_menu.html.erb
+++ b/app/views/shared/_bootstrap_nav_menu.html.erb
@@ -51,7 +51,7 @@ if user_signed_in?
   items['Add'] = {
     items: {
       Entity: "/entities/new",
-      List: "/list/add",
+      List: "/lists/new",
       Map: "/maps/new"
     }
   }

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,0 +1,2 @@
+PaperTrail.config.track_associations = false
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Lilsis::Application.routes.draw do
       get 'references'
       get 'giving'
       get 'funding'
+      get 'modifications'
     end
   end
 

--- a/db/migrate/20160712173138_add_object_changes_to_versions.rb
+++ b/db/migrate/20160712173138_add_object_changes_to_versions.rb
@@ -1,0 +1,12 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration
+  # The largest text column available in all supported RDBMS.
+  # See `create_versions.rb` for details.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160202003823) do
+ActiveRecord::Schema.define(version: 20160712173138) do
 
   create_table "address", force: true do |t|
     t.integer  "entity_id",    limit: 8,                   null: false
@@ -1396,12 +1396,13 @@ ActiveRecord::Schema.define(version: 20160202003823) do
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
   create_table "versions", force: true do |t|
-    t.string   "item_type",  null: false
-    t.integer  "item_id",    null: false
-    t.string   "event",      null: false
+    t.string   "item_type",                         null: false
+    t.integer  "item_id",                           null: false
+    t.string   "event",                             null: false
     t.string   "whodunnit"
     t.text     "object"
     t.datetime "created_at"
+    t.text     "object_changes", limit: 2147483647
   end
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -115,31 +115,4 @@ RSpec.describe ListsController, type: :controller do
     
   end
 
-  describe 'version changes' do
-    
-    before(:each) do 
-      @lc = ListsController.new
-      @changeset = {"is_ranked"=>[false, true], "name"=>['bob', 'alice']}
-    end
-
-    it 'turns a hash into a string' do
-      expect(@lc.version_changes(@changeset)).to be_a(String)
-    end
-    
-    it 'prettifies the hash'
-    
-  end
-
-  describe 'nil_string' do
-
-    it 'returns "nil" if given nil' do
-      expect(ListsController.nil_string(nil)).to eq("nil")
-    end
-    
-    it 'returns the obj if not given nil' do 
-      expect(ListsController.nil_string("something")).to eq("something")
-    end
-    
-  end
-
 end

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -95,5 +95,51 @@ RSpec.describe ListsController, type: :controller do
       end
       
     end
+
+    describe 'modifications' do
+      
+      before(:each) do 
+        @new_list = create(:list)
+        get(:modifications, {id: @new_list.id})
+      end
+      
+      it 'renders modifications template' do 
+        expect(response).to render_template(:modifications)
+      end
+
+      it 'has @versions' do 
+        expect(assigns(:versions)).to eq(@new_list.versions)
+      end
+      
+    end
+    
   end
+
+  describe 'version changes' do
+    
+    before(:each) do 
+      @lc = ListsController.new
+      @changeset = {"is_ranked"=>[false, true], "name"=>['bob', 'alice']}
+    end
+
+    it 'turns a hash into a string' do
+      expect(@lc.version_changes(@changeset)).to be_a(String)
+    end
+    
+    it 'prettifies the hash'
+    
+  end
+
+  describe 'nil_string' do
+
+    it 'returns "nil" if given nil' do
+      expect(ListsController.nil_string(nil)).to eq("nil")
+    end
+    
+    it 'returns the obj if not given nil' do 
+      expect(ListsController.nil_string("something")).to eq("something")
+    end
+    
+  end
+
 end

--- a/spec/factories/references.rb
+++ b/spec/factories/references.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :ref, class: Reference do
+    object_model 'list'
+  end
+end

--- a/spec/helpers/lists_helper_spec.rb
+++ b/spec/helpers/lists_helper_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+
+describe ListsHelper do
+  describe '#nil_string' do
+    
+    it 'returns "nil" if given nil' do
+      expect(helper.nil_string(nil)).to eq("nil")
+    end
+    
+    it 'returns the obj if not given nil' do 
+      expect(helper.nil_string("something")).to eq("something")
+    end
+  end
+end
+

--- a/spec/models/list_entity_spec.rb
+++ b/spec/models/list_entity_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe ListEntity do  
+
+    it 'retrieves all List Entities for a list_id' do 
+      list = create(:list)
+      inc = create(:mega_corp_inc)
+      llc = create(:mega_corp_llc)
+      inc_entity = ListEntity.find_or_create_by(list_id: list.id, entity_id: inc.id)
+      ListEntity.find_or_create_by(list_id: list.id, entity_id: llc.id)
+      inc_entity.destroy
+      expect(ListEntity.where(list_id: list.id).count).to eq(1)
+      expect(ListEntity.unscoped.where(list_id: list.id).count).to eq(2)
+    end
+  
+  context 'after destroying a list entity' do 
+    it  're-adding the same one creates a new entry' do
+      list = create(:list)
+      inc = create(:mega_corp_inc)
+      
+      le = ListEntity.find_or_create_by(list_id: list.id, entity_id: inc.id)
+      expect(ListEntity.count).to eql(2)
+      expect(ListEntity.unscoped.count).to eql(2)
+      le.destroy
+      expect(ListEntity.count).to eql(1)
+      expect(ListEntity.unscoped.count).to eql(2)
+      expect(ListEntity.unscoped.deleted.last).to eql(le)
+      le2 = ListEntity.find_or_create_by(list_id: list.id, entity_id: inc.id)
+      expect(ListEntity.count).to eql(2)
+      expect(ListEntity.unscoped.count).to eql(3)
+      expect(le.id).not_to eq(le2.id)
+    end
+  end
+  
+end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -108,4 +108,21 @@ describe List do
       expect(List.unscoped.deleted.all.count).to eq(2)
     end
   end
+
+  context 'Using paper_trail for versioning' do
+    with_versioning do
+      it 'records created, modified, and deleted versions' do 
+        l = create(:list)
+        expect(l.versions.size).to eq(1)
+        l.name = "change the name name!"
+        l.save
+        expect(l.versions.size).to eq(2)
+        expect(l.versions.last.event).to eq('update')
+        l.destroy
+        expect(l.versions.size).to eq(3)
+        # this is 'update' and not destroy because the implementation of soft delete
+        expect(l.versions.last.event).to eq('update')
+      end
+    end
+  end
 end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -107,6 +107,7 @@ describe List do
       expect(List.unscoped.active.all.count).to eq(c)
       expect(List.unscoped.deleted.all.count).to eq(2)
     end
+
   end
 
   context 'Using paper_trail for versioning' do
@@ -125,4 +126,24 @@ describe List do
       end
     end
   end
+
+  context 'after destroying a list entity' do 
+   it  're-adding the same one creates a new entry' do
+     list = create(:list)
+     inc = create(:mega_corp_inc)
+     
+     le = ListEntity.find_or_create_by(list_id: list.id, entity_id: inc.id)
+     expect(ListEntity.count).to eql(2)
+     expect(ListEntity.unscoped.count).to eql(2)
+     le.destroy
+     expect(ListEntity.count).to eql(1)
+     expect(ListEntity.unscoped.count).to eql(2)
+     expect(ListEntity.unscoped.deleted.last).to eql(le)
+     le2 = ListEntity.find_or_create_by(list_id: list.id, entity_id: inc.id)
+     expect(ListEntity.count).to eql(2)
+     expect(ListEntity.unscoped.count).to eql(3)
+     expect(le.id).not_to eq(le2.id)
+   end
+  end
+
 end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -127,23 +127,6 @@ describe List do
     end
   end
 
-  context 'after destroying a list entity' do 
-   it  're-adding the same one creates a new entry' do
-     list = create(:list)
-     inc = create(:mega_corp_inc)
-     
-     le = ListEntity.find_or_create_by(list_id: list.id, entity_id: inc.id)
-     expect(ListEntity.count).to eql(2)
-     expect(ListEntity.unscoped.count).to eql(2)
-     le.destroy
-     expect(ListEntity.count).to eql(1)
-     expect(ListEntity.unscoped.count).to eql(2)
-     expect(ListEntity.unscoped.deleted.last).to eql(le)
-     le2 = ListEntity.find_or_create_by(list_id: list.id, entity_id: inc.id)
-     expect(ListEntity.count).to eql(2)
-     expect(ListEntity.unscoped.count).to eql(3)
-     expect(le.id).not_to eq(le2.id)
-   end
-  end
+  
 
 end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -72,4 +72,40 @@ describe List do
       expect(list.legacy_url('bam')).to eq("/list/8/Fortune_1000_Companies/bam")
     end
   end
+
+  context 'SoftDelete' do
+    it 'removes item from the count but not he unscoped count' do
+      l = create(:list)
+      expect(List.count).to eq(List.unscoped.count)
+      l.destroy
+      expect(List.count).not_to eq(List.unscoped.count)
+    end
+    
+    it 'sets is_deleted to true' do
+      l = create(:list)
+      expect(l.is_deleted).to eq(false)
+      l.destroy
+      expect(l.is_deleted).to eq(true)
+    end
+
+    it 'List.all returns lists that are not deleted and List.unscoped.deleted returns the deleted lists' do
+      c = List.count
+      list1 = create(:list, name: 'list1')
+      list2 = create(:list, name: 'list2')
+      expect(List.all.count).to eq(c + 2)
+      expect(List.unscoped.all.count).to eq(c + 2)
+      expect(List.unscoped.active.all.count).to eq(c + 2)
+      expect(List.unscoped.deleted.all.count).to eq(0)
+      list1.destroy
+      expect(List.all.count).to eq(c + 1)
+      expect(List.unscoped.all.count).to eq(c + 2)
+      expect(List.active.all.count).to eq(c + 1)
+      expect(List.unscoped.deleted.all.count).to eq(1)
+      list2.destroy
+      expect(List.all.count).to eq(c)
+      expect(List.unscoped.all.count).to eq(c + 2)
+      expect(List.unscoped.active.all.count).to eq(c)
+      expect(List.unscoped.deleted.all.count).to eq(2)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'capybara/rspec'
 require 'devise'
+require 'paper_trail/frameworks/rspec'
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/views/lists/modifications.html.erb_spec.rb
+++ b/spec/views/lists/modifications.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper' 
+
+describe 'lists/modifications.html.erb' do
+  with_versioning do
+    describe 'layout' do
+      include ListsHelper
+      before do
+        l = create(:list)
+        l.name = "new name"
+        l.save
+        l.is_featured = true
+        l.save
+        assign(:list, l)
+        assign(:versions, Kaminari.paginate_array(List.find(l.id).versions.reverse).page(params[:page]).per(5))
+        render
+      end
+      
+      it 'contains header' do
+        expect(rendered).to have_css("#list-header")
+      end
+      
+      it 'contains tabs' do
+        expect(rendered).to have_css(".list_tabs")
+        expect(rendered).to have_css(".tab")
+      end
+
+      it 'contains table' do
+        expect(rendered).to have_css("table")
+        expect(rendered).to have_css("thead")
+        expect(rendered).to have_css("tr", :count => 3)
+      end
+    end
+  end
+end

--- a/spec/views/lists/modifications.html.erb_spec.rb
+++ b/spec/views/lists/modifications.html.erb_spec.rb
@@ -10,8 +10,12 @@ describe 'lists/modifications.html.erb' do
         l.save
         l.is_featured = true
         l.save
+        inc = create(:mega_corp_inc)
+        inc_entity = ListEntity.find_or_create_by(list_id: l.id, entity_id: inc.id)
+        inc_entity.destroy
         assign(:list, l)
         assign(:versions, Kaminari.paginate_array(List.find(l.id).versions.reverse).page(params[:page]).per(5))
+        assign(:all_entities, ListEntity.unscoped.all.where(list_id: l.id).page(params[:page]).per(5))
         render
       end
       
@@ -24,10 +28,14 @@ describe 'lists/modifications.html.erb' do
         expect(rendered).to have_css(".tab")
       end
 
-      it 'contains table' do
-        expect(rendered).to have_css("table")
-        expect(rendered).to have_css("thead")
-        expect(rendered).to have_css("tr", :count => 3)
+      it 'contains 2 tables' do
+        expect(rendered).to have_css("table", :count => 2)
+        expect(rendered).to have_css("thead", :count => 2)
+        
+      end
+      it 'contains 5 <tr> elements' do
+        # 3 for each version, 2 for created and deleted entity
+        expect(rendered).to have_css("tr", :count => 5)
       end
     end
   end


### PR DESCRIPTION
closes issue #8 
- Adds a list modification page, replicating the /modifications page from symfony
- uses the paper_trail gem to keep track of changes to list
- Will require running **db:migrate**
- Previously List and ListEntity _.destroy_  did not call `soft_delete` . They do now. Accordingly any changes to lists made prior to this pull request will not be visible.
