### PR TITLE
Relationship Display Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ data/indivs*
 
 # symlinked asessts
 test/assets
+test/vendor

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ end
 
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
+gem 'bootstrap-datepicker-rails'
 
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 # gem 'turbolinks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       rails (>= 3.1.0)
     binding_of_caller (0.7)
       debug_inspector (>= 0.0.1)
+    bootstrap-datepicker-rails (1.6.4.1)
+      railties (>= 3.0)
     buftok (0.2.0)
     builder (3.2.2)
     capybara (2.4.4)
@@ -367,6 +369,7 @@ DEPENDENCIES
   better_errors (= 0.7.0)
   bettertabs
   binding_of_caller (= 0.7.0)
+  bootstrap-datepicker-rails
   bootsy!
   capybara
   capybara-webkit

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,6 +22,7 @@
 //= require bootstrap
 //= require datatables-bootstrap
 //= require bootsy
+//= require bootstrap-datepicker
 //= require twitter/typeahead
 //= require hogan-3.0.1.js
 //= require d3.v4.min.js

--- a/app/assets/javascripts/pages/referenceModal.js
+++ b/app/assets/javascripts/pages/referenceModal.js
@@ -1,0 +1,42 @@
+var referenceModal = function(){
+  $('#data_date').datepicker({ format: "yyyy-mm-dd" });
+
+  $('#reference-form').submit(function(event){
+    if (this.checkValidity()) {
+      // only prevent the default action and submit using ajax
+      // if the form is valid. If it's not, then the browser will
+      // not submit the form instead show validations
+      event.preventDefault();
+      var statusCode =  {
+        201: function() {
+          location.reload(); // reload the page
+        },
+        400: function(jqXHR) {
+          // Display an alert showing the ActiveModel
+          var errors = jqXHR.responseJSON.errors;
+          var html = Object.keys(errors).map(function(key){
+            return "<p><strong>" + key + ":  </strong>" + errors[key] + "</p>";
+          }).join();
+          $('#reference-errors').html(html);
+          $('#reference-error-alert').show();
+          
+          $('#reference-loading').hide();
+          $('form').show();
+          $('.modal-footer').show();
+        }
+      };
+
+      $.ajax({
+        type: 'POST',
+        url: '/references',
+        data: $('#reference-form').serialize(),
+        statusCode: statusCode
+      });
+      $('#reference-loading').show();
+      $('form').hide();
+      $('.modal-footer').hide();
+    }
+  });
+  
+  
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,6 +11,7 @@
  *= require_self
  *= require bootstrap
  *= require bootsy
+ *= require bootstrap-datepicker3
  *= require typeahead
  *= require jquery.dataTables
  *= require dataTables.editor

--- a/app/assets/stylesheets/entities.css.scss
+++ b/app/assets/stylesheets/entities.css.scss
@@ -2,16 +2,6 @@
 
 $tiny_image_size: 35px;
 
-// helpers
-.top-1em {
-  padding-top: 1em;
-}
-
-.m-left-1em {
-  margin-left: 1em;
-}
-
-// 
 .entity_update {
 	padding-top: 1em;
 	padding-bottom: 1em;
@@ -133,9 +123,6 @@ $tiny_image_size: 35px;
   cursor: default;
 }
 
-.thin-grey-bottom-border {
-  border-bottom: 1px solid #e7e7e7;
-}
 /* summary toggle */
 #entity-summary {
   line-height: 1.3em;

--- a/app/assets/stylesheets/entities.css.scss
+++ b/app/assets/stylesheets/entities.css.scss
@@ -98,12 +98,12 @@ $tiny_image_size: 35px;
   /* width: 350px; */
 }
 
-#entity-actions {
+#actions {
   margin-top: 1.2em;
   padding-bottom: 1em;
 }
 
-#entity-actions a {
+#actions a {
   position: relative;
   font-size: 14px;
   top: -6px;
@@ -118,18 +118,18 @@ $tiny_image_size: 35px;
   border-radius: 10px;
 }
 
-#entity-actions a:hover {
+#actions a:hover {
   color: #000;
   background-color: #ddf;
   text-decoration: none;
 }
 
-#entity-actions a.disabled_action {
+#actions a.disabled_action {
   color: #888;
   background-color: #f8f8f8;
 }
 
-#entity-actions a.disabled_action:hover {
+#actions a.disabled_action:hover {
   cursor: default;
 }
 

--- a/app/assets/stylesheets/helpers.css.scss
+++ b/app/assets/stylesheets/helpers.css.scss
@@ -1,0 +1,32 @@
+/* helper css utilities */
+@import "globals";
+
+.link-blue {
+  color: $link_blue;
+}
+
+.top-1em {
+  padding-top: 1em;
+}
+
+.m-left-1em {
+  margin-left: 1em;
+}
+
+.pad-right-1em {
+  padding-right: 1em;
+}
+
+.pad-right-08em {
+  padding-right: 0.8em;
+}
+
+.thin-grey-bottom-border {
+  border-bottom: 1px solid #e7e7e7;
+}
+
+.borderless {
+   th, td { 
+    border-top: none !important; 
+  }
+}

--- a/app/assets/stylesheets/references.scss
+++ b/app/assets/stylesheets/references.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the References controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/references.scss
+++ b/app/assets/stylesheets/references.scss
@@ -1,3 +1,7 @@
 // Place all the styles related to the References controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+#add-reference-modal .form-group input {
+  width: 80%;
+}

--- a/app/assets/stylesheets/relationships.scss
+++ b/app/assets/stylesheets/relationships.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Relationships controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/relationships.scss
+++ b/app/assets/stylesheets/relationships.scss
@@ -1,3 +1,13 @@
 // Place all the styles related to the Relationships controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+
+
+#source-links-table td {
+  font-size: 1em;
+}
+
+#source-links-table tbody a {
+  
+}

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -1,0 +1,21 @@
+class ReferencesController < ApplicationController
+  before_filter :auth
+
+  def create
+    if Reference.create( reference_params.merge({last_user_id: current_user.sf_guard_user_id}) )
+      render :nothing => true
+    else
+      # handle errors
+      render :nothing => true  
+    end
+  end
+
+  def destroy
+  end
+
+  private
+  def reference_params
+    params.permit(:object_id, :object_model, :source, :name, :fields, :source_detail, :publication_date, :ref_type)
+  end
+
+end

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -2,20 +2,30 @@ class ReferencesController < ApplicationController
   before_filter :auth
 
   def create
-    if Reference.create( reference_params.merge({last_user_id: current_user.sf_guard_user_id}) )
-      render :nothing => true
+    ref = Reference.new( reference_params.merge({last_user_id: current_user.sf_guard_user_id}) )
+    if ref.save
+      params[:data][:object_model].constantize.find(params[:data][:object_id].to_i).touch
+      head :created
     else
-      # handle errors
-      render :nothing => true  
+      # send back errors
+      render json: {errors: ref.errors}, status: :bad_request
     end
   end
 
   def destroy
+    check_permission "deleter"
+    begin
+      Reference.find(params[:id]).destroy!
+    rescue ActiveRecord::RecordNotFound
+      head :bad_request
+    else
+      head :ok
+    end
   end
 
   private
   def reference_params
-    params.permit(:object_id, :object_model, :source, :name, :fields, :source_detail, :publication_date, :ref_type)
+    params.require(:data).permit(:object_id, :object_model, :source, :name, :fields, :source_detail, :publication_date, :ref_type)
   end
 
 end

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -5,6 +5,9 @@ class ReferencesController < ApplicationController
     ref = Reference.new( reference_params.merge({last_user_id: current_user.sf_guard_user_id}) )
     if ref.save
       params[:data][:object_model].constantize.find(params[:data][:object_id].to_i).touch
+      unless excerpt_params['excerpt'].blank?
+        ref.create_reference_excerpt(excerpt_params)
+      end
       head :created
     else
       # send back errors
@@ -28,4 +31,8 @@ class ReferencesController < ApplicationController
     params.require(:data).permit(:object_id, :object_model, :source, :name, :fields, :source_detail, :publication_date, :ref_type)
   end
 
+  def excerpt_params
+    params.require(:data).permit(:excerpt)
+  end
+  
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,6 +1,11 @@
 class RelationshipsController < ApplicationController
-  
+  before_action :set_relationship
+ 
   def show
+  end
+
+  def set_relationship
+    @relationship = Relationship.find(params[:id])
   end
 
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,6 @@
+class RelationshipsController < ApplicationController
+  
+  def show
+  end
+
+end

--- a/app/helpers/references_helper.rb
+++ b/app/helpers/references_helper.rb
@@ -1,0 +1,2 @@
+module ReferencesHelper
+end

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,8 +1,8 @@
 module RelationshipsHelper
-	def rel_link(rel, name=nil)
-		name ||= rel.name
-		link_to name, rel.legacy_url
-	end
+  def rel_link(rel, name=nil)
+    name ||= rel.name
+    link_to name, rel.legacy_url
+  end
 
   def relationship_date(rel)
     start = rel.start_date
@@ -40,4 +40,13 @@ module RelationshipsHelper
     return (abbreviate ? "'" + year[2..4] : year) if year.to_i > 0
     ""
   end
+
+  def title_in_parens(rel)
+    if rel.title.nil?
+      return ""
+    else
+      return " (" + rel.title + ") "
+    end
+  end
+  
 end

--- a/app/models/concerns/relationship_display.rb
+++ b/app/models/concerns/relationship_display.rb
@@ -5,47 +5,81 @@ module RelationshipDisplay
   end
 
   # This provides an array of text that goes after Entity one's name 
-  # and  after Entity two's name
+  # and after Entity two's name
   # Links are generated in the view. 
   def description_sentence
     case category_id
     when Relationship::POSITION_CATEGORY
       [ " #{has_had} a position#{title_in_parens}at ", "" ]
     when Relationship::EDUCATION_CATEGORY
-      
+      [ " #{is_was} a student of ", ""]
     when Relationship::MEMBERSHIP_CATEGORY
-
+      [ " #{is_was} a member of ", ""]
     when Relationship::FAMILY_CATEGORY
-
+      [ " and ", " #{are_were} in a family" ]
     when Relationship::DONATION_CATEGORY
-
+      [ " gave money to ", ""]
     when Relationship::TRANSATION_CATEGORY
-
+      [ " and ", " #{did_do} business" ]
     when Relationship::LOBBYING_CATEGORY
-
+      [ " #{lobbies_lobbied} ", ""]
     when Relationship::SOCIAL_CATEGORY
-
+      if !description1.nil? and description1 == description2
+        [ " and ", " #{are_were} #{description1.pluralize}" ]
+      else
+        [ " and ", " #{have_had} a social relationship" ]
+      end
     when Relationship::PROFESSIONAL_CATEGORY
-
+      if !description1.nil? and description1 == description2
+        [ " and ", " #{are_were} #{description1.pluralize}" ]
+      else
+        [ " and ", " #{have_had} a professional relationship" ]
+      end
     when Relationship::OWNERSHIP_CATEGORY
-
+      [ " #{is_was} an owner of ", ""]
     when Relationship::HIERARCHY_CATEGORY
-
-    when Relationship::GENERIC_CATEGORY   
+      [ " and ", " #{have_had} a hierarchical relationship" ]
     else
-    end
-  end  
-  
-  def has_had
-    if is_current == true
-      'has'
-    elsif is_current == false
-      'had'
-    else
-      'has/had'
+      [" and ", " #{have_had} a generic relationship"]
     end
   end
   
+  def has_had
+    RelationshipDisplay.is_current_helper('has', 'had').call(is_current)
+  end
+  
+  def have_had
+    RelationshipDisplay.is_current_helper('have', 'had').call(is_current)
+  end
+
+  def is_was
+    RelationshipDisplay.is_current_helper('is', 'was').call(is_current)
+  end
+
+  def are_were
+    RelationshipDisplay.is_current_helper('are','were').call(is_current)
+  end
+  
+  def did_do
+    RelationshipDisplay.is_current_helper('did', 'do').call(is_current)
+  end
+
+  def lobbies_lobbied
+    RelationshipDisplay.is_current_helper('lobbies', 'lobbied').call(is_current)
+  end
+
+  def self.is_current_helper(true_verb, false_verb)
+    lambda do |is_current|
+      if is_current == true
+        true_verb
+      elsif is_current == false
+        false_verb
+      else
+        true_verb + '/' + false_verb
+      end
+    end
+  end
+
   def title_in_parens
     title.nil? ? "" : " (#{title}) "
   end

--- a/app/models/concerns/relationship_display.rb
+++ b/app/models/concerns/relationship_display.rb
@@ -1,0 +1,8 @@
+module RelationshipDisplay
+  extend ActiveSupport::Concern
+  # included do end
+  module ClassMethods
+  end
+  
+  
+end

--- a/app/models/concerns/relationship_display.rb
+++ b/app/models/concerns/relationship_display.rb
@@ -3,6 +3,51 @@ module RelationshipDisplay
   # included do end
   module ClassMethods
   end
+
+  # This provides an array of text that goes after Entity one's name 
+  # and  after Entity two's name
+  # Links are generated in the view. 
+  def description_sentence
+    case category_id
+    when Relationship::POSITION_CATEGORY
+      [ " #{has_had} a position#{title_in_parens}at ", "" ]
+    when Relationship::EDUCATION_CATEGORY
+      
+    when Relationship::MEMBERSHIP_CATEGORY
+
+    when Relationship::FAMILY_CATEGORY
+
+    when Relationship::DONATION_CATEGORY
+
+    when Relationship::TRANSATION_CATEGORY
+
+    when Relationship::LOBBYING_CATEGORY
+
+    when Relationship::SOCIAL_CATEGORY
+
+    when Relationship::PROFESSIONAL_CATEGORY
+
+    when Relationship::OWNERSHIP_CATEGORY
+
+    when Relationship::HIERARCHY_CATEGORY
+
+    when Relationship::GENERIC_CATEGORY   
+    else
+    end
+  end  
   
+  def has_had
+    if is_current == true
+      'has'
+    elsif is_current == false
+      'had'
+    else
+      'has/had'
+    end
+  end
+  
+  def title_in_parens
+    title.nil? ? "" : " (#{title}) "
+  end
   
 end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -1,6 +1,6 @@
 class Reference < ActiveRecord::Base
   include SingularTable
-  @@ref_types = {1=>"Generic", 2=>"FEC Filing"}
+  @@ref_types = {1=>"Generic", 2=>"FEC Filing", 3=>"Newspaper", 4=>"Government Document"}
   
   def ref_types
     @@ref_types

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -1,11 +1,14 @@
 class Reference < ActiveRecord::Base
   include SingularTable
+  has_paper_trail :on => [:update, :destroy]
+  
   @@ref_types = {1=>"Generic", 2=>"FEC Filing", 3=>"Newspaper", 4=>"Government Document"}
   
   def ref_types
     @@ref_types
   end
-  
+
+  validates_presence_of :source, :object_id, :object_model
   has_one :os_match
   has_one :os_donation, :through => :os_match
 end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -8,7 +8,19 @@ class Reference < ActiveRecord::Base
     @@ref_types
   end
 
+  # Returns the reference types as an array: [ [name, number], ... ]
+  # Removes the FEC filings option
+  # Used by the add reference modal in _reference_new.html.erb
+  def self.ref_type_options
+    @@ref_types.to_a.map { |x| x.reverse }.delete_if { |x| x[1] == 2 }
+  end
+
+  def excerpt
+    reference_excerpt.nil? ? nil : reference_excerpt.body
+  end
+
   validates_presence_of :source, :object_id, :object_model
   has_one :os_match
+  has_one :reference_excerpt
   has_one :os_donation, :through => :os_match
 end

--- a/app/models/reference_excerpt.rb
+++ b/app/models/reference_excerpt.rb
@@ -1,0 +1,6 @@
+class ReferenceExcerpt < ActiveRecord::Base
+  include SingularTable
+  validates_presence_of :body
+  
+  belongs_to :reference
+end

--- a/app/models/reference_excerpt.rb
+++ b/app/models/reference_excerpt.rb
@@ -1,5 +1,6 @@
 class ReferenceExcerpt < ActiveRecord::Base
   include SingularTable
+  alias_attribute :excerpt, :body
   validates_presence_of :body
   
   belongs_to :reference

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -241,6 +241,16 @@ class Relationship < ActiveRecord::Base
     membership.nil? ? nil : membership.dues
   end
   
+  ## Ownership ##
+  
+  def percent_stake
+    ownership.nil? ? nil : ownership.percent_stake
+  end
+
+  def shares_owned
+    ownership.nil? ? nil : ownership.shares
+  end
+
   ########################
   # Open Secrets Helpers #
   ########################

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -2,7 +2,8 @@ class Relationship < ActiveRecord::Base
   include SingularTable
   include SoftDelete
   include Referenceable
-
+  include RelationshipDisplay
+  
   POSITION_CATEGORY = 1
   EDUCATION_CATEGORY = 2
   MEMBERSHIP_CATEGORY = 3
@@ -198,6 +199,7 @@ class Relationship < ActiveRecord::Base
       description1
     end
   end
+  
     
   ########################
   # Open Secrets Helpers #

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -32,6 +32,8 @@ class Relationship < ActiveRecord::Base
   has_many :fec_filings, inverse_of: :relationship, dependent: :destroy
   belongs_to :category, class_name: "RelationshipCategory", inverse_of: :relationships
 
+  belongs_to :last_user, class_name: "SfGuardUser", foreign_key: "last_user_id"
+
   # Open Secrets 
   has_many :os_matches, inverse_of: :relationship
   has_many :os_donations, through: :os_matches
@@ -119,12 +121,13 @@ class Relationship < ActiveRecord::Base
     hash
   end
 
-  def legacy_url
-    self.class.legacy_url(id)
+  def legacy_url(action=nil)
+    self.class.legacy_url(id, action)
   end
 
-  def self.legacy_url(id)
-    "/relationship/view/id/" + id.to_s
+  def self.legacy_url(id, action=nil)
+    action = action.nil? ? "view" : action
+    "/relationship/#{action}/id/#{id.to_s}"
   end
 
   def full_legacy_url

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -213,6 +213,9 @@ class Relationship < ActiveRecord::Base
     end
   end
   
+  def details 
+    RelationshipDetails.new(self).details
+  end
     
   ########################
   # Open Secrets Helpers #

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -20,8 +20,10 @@ class Relationship < ActiveRecord::Base
   has_many :links, inverse_of: :relationship, dependent: :destroy
   belongs_to :entity, foreign_key: "entity1_id"
   belongs_to :related, class_name: "Entity", foreign_key: "entity2_id"
-  has_many :note_relationships, inverse_of: :relationship
-  has_many :notes, through: :note_relationships, inverse_of: :relationships
+  
+  # has_many :note_relationships, inverse_of: :relationship
+  # has_many :notes, through: :note_relationships, inverse_of: :relationships
+  
   has_one :position, inverse_of: :relationship, dependent: :destroy
   has_one :education, inverse_of: :relationship, dependent: :destroy
   has_one :membership, inverse_of: :relationship, dependent: :destroy
@@ -171,6 +173,14 @@ class Relationship < ActiveRecord::Base
 
   def is_executive
     position.nil? ? nil : position.is_executive
+  end
+
+  def is_employee
+    position.nil? ? nil : position.is_employee
+  end
+
+  def compensation
+    position.nil? ? nil : position.compensation
   end
 
   def is_member?

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -171,6 +171,10 @@ class Relationship < ActiveRecord::Base
     RelationshipDetails.new(self).details
   end
 
+  def source_links
+    Reference.where(object_id: self.id, object_model: "Relationship")
+  end
+
   ###############################
   # Extension Helpers & Getters #
   ###############################

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -167,6 +167,15 @@ class Relationship < ActiveRecord::Base
     desc
   end
 
+  def details 
+    RelationshipDetails.new(self).details
+  end
+
+  ###############################
+  # Extension Helpers & Getters #
+  ###############################
+
+ 
   def is_board
     position.nil? ? nil : position.is_board
   end
@@ -204,7 +213,6 @@ class Relationship < ActiveRecord::Base
       elsif is_education? and education.degree.present?
         return education.degree.name
       elsif is_family?
-        
       else
         return nil
       end
@@ -213,10 +221,26 @@ class Relationship < ActiveRecord::Base
     end
   end
   
-  def details 
-    RelationshipDetails.new(self).details
+  ## education ##
+  
+  def degree
+    education.nil? ? nil : education.degree.name
   end
     
+  def education_field
+    education.nil? ? nil : education.field
+  end
+
+  def is_dropout
+    education.nil? ? nil : education.is_dropout
+  end
+
+  ## membership ##
+  
+  def membership_dues
+    membership.nil? ? nil : membership.dues
+  end
+  
   ########################
   # Open Secrets Helpers #
   ########################

--- a/app/views/entities/_actions.html.erb
+++ b/app/views/entities/_actions.html.erb
@@ -1,5 +1,5 @@
 <div class="row thin-grey-bottom-border">
-    <div id="entity-actions" class="col-md-8"> 
+    <div id="actions" class="col-md-8"> 
         <%= link_to "add relationship", @entity.legacy_url("addRelationship") %>
         <%= link_to "edit", @entity.legacy_url("edit") %>
         <%= link_to "flag", "/home/contact?type=flag" %>
@@ -16,12 +16,9 @@
             <% end %>
         <% end %>
     </div>
+    
+    <% cache ['entity_history', @entity ] do %>
+        <%= render partial: 'shared/entity_history', locals: {entity: @entity} %>
+    <% end %>
 
-    <div id="entity-edited-history" class="col-md-4">
-        Edited by<strong>
-        <%= link_to @entity.last_user.user.username, legacy_user_path(@entity.last_user.user) %>
-        </strong>
-        <%= time_ago_in_words(@entity.updated_at) %> ago
-        <%= link_to "History", @entity.legacy_url("modifications") %>
-    </div>
 </div>

--- a/app/views/relationships/_actions.html.erb
+++ b/app/views/relationships/_actions.html.erb
@@ -1,22 +1,19 @@
-<div class="row thin-grey-bottom-border">
-    <div id="actions" class="col-md-8"> 
-        <% if signed_in %>        
-            <%= link_to "edit", @relationship.legacy_url('edit')  %>
-        <% end %>
-        <%= link_to "flag", "/home/contact?type=flag" %>
-        <% if signed_in and @current_user.has_legacy_permission 'deleter' %>
-            <%=  link_to "remove", @relationship.legacy_url('remove') %>
-        <% end %>
-    </div>
-
-    <% cache ['edited_history', @relationship ] do %>
-        <div id="entity-edited-history" class="col-md-4">
-            Edited by<strong>
-            <%= link_to @relationship.last_user.user.username, legacy_user_path(@relationship.last_user.user) %>
-            </strong>
-            <%= time_ago_in_words(@relationship.updated_at) %> ago
-            <%= link_to "History", @relationship.legacy_url("modifications") %>
-        </div>
+<div id="actions" class="col-md-8"> 
+    <% if signed_in %>        
+        <%= link_to "edit", @relationship.legacy_url('edit')  %>
     <% end %>
-
+    <%= link_to "flag", "/home/contact?type=flag" %>
+    <% if signed_in and @current_user.has_legacy_permission 'deleter' %>
+        <%=  link_to "remove", @relationship.legacy_url('remove') %>
+    <% end %>
 </div>
+
+<% cache ['edited_history', @relationship ] do %>
+    <div id="entity-edited-history" class="col-md-4">
+        Edited by<strong>
+        <%= link_to @relationship.last_user.user.username, legacy_user_path(@relationship.last_user.user) %>
+        </strong>
+        <%= time_ago_in_words(@relationship.updated_at) %> ago
+        <%= link_to "History", @relationship.legacy_url("modifications") %>
+    </div>
+<% end %>

--- a/app/views/relationships/_actions.html.erb
+++ b/app/views/relationships/_actions.html.erb
@@ -1,0 +1,22 @@
+<div class="row thin-grey-bottom-border">
+    <div id="actions" class="col-md-8"> 
+        <% if signed_in %>        
+            <%= link_to "edit", @relationship.legacy_url('edit')  %>
+        <% end %>
+        <%= link_to "flag", "/home/contact?type=flag" %>
+        <% if signed_in and @current_user.has_legacy_permission 'deleter' %>
+            <%=  link_to "remove", @relationship.legacy_url('remove') %>
+        <% end %>
+    </div>
+
+    <% cache ['edited_history', @relationship ] do %>
+        <div id="entity-edited-history" class="col-md-4">
+            Edited by<strong>
+            <%= link_to @relationship.last_user.user.username, legacy_user_path(@relationship.last_user.user) %>
+            </strong>
+            <%= time_ago_in_words(@relationship.updated_at) %> ago
+            <%= link_to "History", @relationship.legacy_url("modifications") %>
+        </div>
+    <% end %>
+
+</div>

--- a/app/views/relationships/_actions.html.erb
+++ b/app/views/relationships/_actions.html.erb
@@ -1,4 +1,4 @@
-<div id="actions" class="col-md-8"> 
+<div id="actions" class="col-md-8 col-sm-6 hidden-xs"> 
     <% if signed_in %>        
         <%= link_to "edit", @relationship.legacy_url('edit')  %>
     <% end %>
@@ -9,7 +9,7 @@
 </div>
 
 <% cache ['edited_history', @relationship ] do %>
-    <div id="entity-edited-history" class="col-md-4">
+    <div id="entity-edited-history" class="col-md-4 col-sm-6 col-xs-6 hidden-xs hidden-sm">
         Edited by<strong>
         <%= link_to @relationship.last_user.user.username, legacy_user_path(@relationship.last_user.user) %>
         </strong>

--- a/app/views/relationships/_details.html.erb
+++ b/app/views/relationships/_details.html.erb
@@ -1,0 +1,4 @@
+<p class="lead thin-grey-bottom-border">Details</p>
+<% details.each do |detail| %>
+    <p><strong><%= detail[0] %>: </strong><%= detail[1] %></p>
+<% end %>

--- a/app/views/relationships/_details.html.erb
+++ b/app/views/relationships/_details.html.erb
@@ -1,4 +1,12 @@
-<p class="lead thin-grey-bottom-border">Details</p>
-<% details.each do |detail| %>
-    <p><strong><%= detail[0] %>: </strong><%= detail[1] %></p>
-<% end %>
+<table class="table table-hover borderless table-condensed">
+    <caption>Details</caption>
+    <thead></thead>
+    <tbody>
+        <% details.each do |detail| %>
+            <tr>
+                <td><strong><%= detail[0] %></strong></td>
+                <td><%= detail[1] %></td>
+            </tr>
+        <% end %>
+    </tbody>
+</table>

--- a/app/views/relationships/_sources.html.erb
+++ b/app/views/relationships/_sources.html.erb
@@ -1,0 +1,18 @@
+<table class="table table-condensed table-hover" id="source-links-table">
+    <thead>
+        <tr>
+            <th><span class="pad-right-1em">Source Links</span>
+                <a href="" class="pad-right-08em"><span title="Add a source" class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
+                <a href=""><span title="Edit sources" class="glyphicon glyphicon-edit" aria-hidden="true"></span></a>
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        <% relationship.source_links.each do |link|  %>
+            <tr>
+                <td><%= link_to link.name, link.source %></td>
+            </tr>
+        <% end %>
+    </tbody>
+</table>
+

--- a/app/views/relationships/_sources.html.erb
+++ b/app/views/relationships/_sources.html.erb
@@ -1,8 +1,8 @@
 <table class="table table-condensed table-hover" id="source-links-table">
     <thead>
         <tr>
-            <th><span class="pad-right-1em">Source Links</span>
-                <a href="" class="pad-right-08em"><span title="Add a source" class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
+            <th><span style="padding-right:1em;">Source Links</span>
+                <a href="#add-reference-modal" class="pad-right-08em" data-toggle="modal" ><span title="Add a source" class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
                 <a href=""><span title="Edit sources" class="glyphicon glyphicon-edit" aria-hidden="true"></span></a>
             </th>
         </tr>

--- a/app/views/relationships/_sources.html.erb
+++ b/app/views/relationships/_sources.html.erb
@@ -10,7 +10,7 @@
     <tbody>
         <% relationship.source_links.each do |link|  %>
             <tr>
-                <td><%= link_to link.name, link.source %></td>
+                <td><%= link_to excerpt( (link.name.blank? ? link.source : link.name) ), link.source %></td>
             </tr>
         <% end %>
     </tbody>

--- a/app/views/relationships/_subtitle.html.erb
+++ b/app/views/relationships/_subtitle.html.erb
@@ -1,1 +1,1 @@
-<h4><%= link_to relationship.entity.name,  entity_path(relationship.entity) %><%=  relationship.description_sentence[0] %><%= link_to relationship.related.name, entity_path(relationship.related) %><%= relationship.description_sentence[1]%></h4> 
+<h4><%= link_to relationship.entity.name,  relationship.entity.legacy_url %><%=  relationship.description_sentence[0] %><%= link_to relationship.related.name, relationship.related.legacy_url %><%= relationship.description_sentence[1]%></h4> 

--- a/app/views/relationships/_subtitle.html.erb
+++ b/app/views/relationships/_subtitle.html.erb
@@ -1,1 +1,1 @@
-<h4><%= link_to relationship.entity.name,  entity_path(relationship.entity) %> has a position <%= title_in_parens(relationship)%> at <%= link_to relationship.related.name, entity_path(relationship.related) %></h4>
+<h4><%= link_to relationship.entity.name,  entity_path(relationship.entity) %><%=  relationship.description_sentence[0] %><%= link_to relationship.related.name, entity_path(relationship.related) %><% relationship.description_sentence[1]%></h4> 

--- a/app/views/relationships/_subtitle.html.erb
+++ b/app/views/relationships/_subtitle.html.erb
@@ -1,1 +1,1 @@
-<h4><%= link_to relationship.entity.name,  entity_path(relationship.entity) %><%=  relationship.description_sentence[0] %><%= link_to relationship.related.name, entity_path(relationship.related) %><% relationship.description_sentence[1]%></h4> 
+<h4><%= link_to relationship.entity.name,  entity_path(relationship.entity) %><%=  relationship.description_sentence[0] %><%= link_to relationship.related.name, entity_path(relationship.related) %><%= relationship.description_sentence[1]%></h4> 

--- a/app/views/relationships/_subtitle.html.erb
+++ b/app/views/relationships/_subtitle.html.erb
@@ -1,0 +1,1 @@
+<h4><%= link_to relationship.entity.name,  entity_path(relationship.entity) %> has a position <%= title_in_parens(relationship)%> at <%= link_to relationship.related.name, entity_path(relationship.related) %></h4>

--- a/app/views/relationships/show.html.erb
+++ b/app/views/relationships/show.html.erb
@@ -16,17 +16,18 @@
         <% end %>
     </div>
 
-    <div class="row">
-        <div class="col-md-8 col-lg-8"> 
-            <div class="row">
-                <%= render partial: 'subtitle', locals: {relationship: @relationship } %>
-            </div>
-            <div class="row top-1em">
-                    <%= render partial: 'details', locals: {details: RelationshipDetails.new(@relationship).details } %>                
+    <% cache ['subtitle_details', @relationship] do %>
+        <div class="row">
+            <div class="col-md-8 col-lg-8"> 
+                <div class="row">
+                    <%= render partial: 'subtitle', locals: {relationship: @relationship } %>
+                </div>
+                <div class="row top-1em">
+                    <%= render partial: 'details', locals: {details: @relationship.details } %>                
+                </div>
             </div>
         </div>
-        
-    </div>
+    <% end %>
 
 
 <%#= render partial: 'source_links' %>

--- a/app/views/relationships/show.html.erb
+++ b/app/views/relationships/show.html.erb
@@ -1,8 +1,8 @@
-<div class="conatiner">
+<div class="container">
 
     <div class="row">
         <% cache ['name', @relationship] do %>
-            <h1><%=  link_to @relationship.name, relationship_path(@relationship) %></h1>
+            <h1><%=  link_to @relationship.name, relationship_path(@relationship), class: "link-blue" %></h1>
         <% end %>
     </div>
 
@@ -16,20 +16,22 @@
         <% end %>
     </div>
 
-    <% cache ['subtitle_details', @relationship] do %>
+    <% cache ['subtitle_details_sources', @relationship] do %>
         <div class="row">
-            <div class="col-md-8 col-lg-8"> 
+            <div class="col-md-6 col-xs-12 col-sm-6"> 
                 <div class="row">
                     <%= render partial: 'subtitle', locals: {relationship: @relationship } %>
                 </div>
                 <div class="row top-1em">
-                    <%= render partial: 'details', locals: {details: @relationship.details } %>
+                    <div class="col-md-10 col-sm-10 col-xs-10">
+                        <%= render partial: 'details', locals: {details: @relationship.details } %>
+                    </div>
                 </div>
+            </div>
+            <div class="col-md-4 col-sm-4 top-1em col-xs-12 pull-right">
+                <%= render partial: 'sources', locals: {relationship: @relationship } %>
             </div>
         </div>
     <% end %>
-
-
-    <%#= render partial: 'source_links' %>
-
+    
 </div>

--- a/app/views/relationships/show.html.erb
+++ b/app/views/relationships/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, @relationship.name) %>
 <div class="container">
 
     <div class="row">

--- a/app/views/relationships/show.html.erb
+++ b/app/views/relationships/show.html.erb
@@ -23,13 +23,13 @@
                     <%= render partial: 'subtitle', locals: {relationship: @relationship } %>
                 </div>
                 <div class="row top-1em">
-                    <%= render partial: 'details', locals: {details: @relationship.details } %>                
+                    <%= render partial: 'details', locals: {details: @relationship.details } %>
                 </div>
             </div>
         </div>
     <% end %>
 
 
-<%#= render partial: 'source_links' %>
+    <%#= render partial: 'source_links' %>
 
 </div>

--- a/app/views/relationships/show.html.erb
+++ b/app/views/relationships/show.html.erb
@@ -1,19 +1,34 @@
 <div class="conatiner">
 
-<% cache ['name', @relationship] do %>
-    <h1><%=  link_to @relationship.name, relationship_path(@relationship) %></h1>
-<% end %>
+    <div class="row">
+        <% cache ['name', @relationship] do %>
+            <h1><%=  link_to @relationship.name, relationship_path(@relationship) %></h1>
+        <% end %>
+    </div>
 
-<% if user_signed_in? %>
-    <%= render partial: 'actions', locals: {signed_in: true } %>
-<% else %>    
-    <% cache ['action_buttons_no_user', @relationship ] do %>
-        <%= render partial: 'actions', locals: {signed_in: false }%>
-    <% end %>        
-<% end %>
+    <div class="row thin-grey-bottom-border">
+        <% if user_signed_in? %>
+            <%= render partial: 'actions', locals: {signed_in: true } %>
+        <% else %>    
+            <% cache ['action_buttons_no_user', @relationship ] do %>
+                <%= render partial: 'actions', locals: {signed_in: false }%>
+            <% end %>        
+        <% end %>
+    </div>
+
+    <div class="row">
+        <div class="col-md-8 col-lg-8"> 
+            <div class="row">
+                <%= render partial: 'subtitle', locals: {relationship: @relationship } %>
+            </div>
+            <div class="row top-1em">
+                    <%= render partial: 'details', locals: {details: RelationshipDetails.new(@relationship).details } %>                
+            </div>
+        </div>
+        
+    </div>
 
 
-<%#= render partial: 'details' %>
 <%#= render partial: 'source_links' %>
 
 </div>

--- a/app/views/relationships/show.html.erb
+++ b/app/views/relationships/show.html.erb
@@ -1,9 +1,18 @@
 <div class="conatiner">
 
-<%#= render partial: 'title' %>
-<h1>RELATIONSHIPS</h1>
+<% cache ['name', @relationship] do %>
+    <h1><%=  link_to @relationship.name, relationship_path(@relationship) %></h1>
+<% end %>
 
-<%#= render partial: 'actions' %>
+<% if user_signed_in? %>
+    <%= render partial: 'actions', locals: {signed_in: true } %>
+<% else %>    
+    <% cache ['action_buttons_no_user', @relationship ] do %>
+        <%= render partial: 'actions', locals: {signed_in: false }%>
+    <% end %>        
+<% end %>
+
+
 <%#= render partial: 'details' %>
 <%#= render partial: 'source_links' %>
 

--- a/app/views/relationships/show.html.erb
+++ b/app/views/relationships/show.html.erb
@@ -33,5 +33,8 @@
             </div>
         </div>
     <% end %>
-    
 </div>
+
+<% if user_signed_in? %>
+    <%= render partial: 'shared/reference_new', locals: {model: @relationship, reference: @reference } %>
+<% end %>

--- a/app/views/relationships/show.html.erb
+++ b/app/views/relationships/show.html.erb
@@ -1,0 +1,10 @@
+<div class="conatiner">
+
+<%#= render partial: 'title' %>
+<h1>RELATIONSHIPS</h1>
+
+<%#= render partial: 'actions' %>
+<%#= render partial: 'details' %>
+<%#= render partial: 'source_links' %>
+
+</div>

--- a/app/views/shared/_entity_history.html.erb
+++ b/app/views/shared/_entity_history.html.erb
@@ -1,4 +1,4 @@
-<div id="entity-edited-history" class="col-md-4">
+<div id="entity-edited-history">
     Edited by<strong>
     <%= link_to entity.last_user.user.username, legacy_user_path(entity.last_user.user) %>
     </strong>

--- a/app/views/shared/_entity_history.html.erb
+++ b/app/views/shared/_entity_history.html.erb
@@ -1,0 +1,7 @@
+<div id="entity-edited-history" class="col-md-4">
+    Edited by<strong>
+    <%= link_to entity.last_user.user.username, legacy_user_path(entity.last_user.user) %>
+    </strong>
+    <%= time_ago_in_words(entity.updated_at) %> ago
+    <%= link_to "History", entity.legacy_url("modifications") %>
+</div>

--- a/app/views/shared/_reference_new.html.erb
+++ b/app/views/shared/_reference_new.html.erb
@@ -1,0 +1,85 @@
+<div class="modal fade" id="add-reference-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h3 class="modal-title">Add a new reference</h3>
+                <h3><small><%= model.name %></small></h3>
+            </div>
+            <div class="modal-body">
+                
+                <!-- Error Alert -->
+                <div id="reference-error-alert" class="alert alert-warning" role="alert" style="display:none;">
+                    <p class="text-center"><strong>We're sorry!</strong>
+                        <p>The LittleSis database had issues with the following fields:</p>
+                        <div id="reference-errors"></div>
+                </div>
+                
+                <!-- Loading -->
+                <div id="reference-loading" style="display: none;">
+                    <h3 class="text-center">Adding a new reference ... </h3>
+                    <div class="progress">
+                        <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%">
+                            <span class="sr-only">Loading</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- FORM -->
+                <%= form_tag("/references", method: 'post', class: "form-horizontal", id:"reference-form") do %>
+
+                    <%= hidden_field(:data, :object_id, value: model.id) %>
+                    <%= hidden_field(:data, :object_model, value: model.class.name) %>
+                    
+                    <div class="form-group form-group-sm">
+                        <%= label_tag(:data_source, "Source URL*", class: "col-sm-2 control-label") %>
+                        <div class="col-sm-10">
+                            <%= url_field(:data, :source, required: true) %>
+                        </div>
+                    </div>
+                    
+                    <div class="form-group form-group-sm">
+                        <%= label_tag(:data_name, "Display Name*", class: "col-sm-2 control-label") %>
+                        <div class="col-sm-10">
+                            <%= text_field(:data, :name, required: true) %>
+                        </div>
+                    </div>
+
+                    <div class="form-group form-group-sm">
+                        <%= label_tag(:data_date, "Publication Date", class: "col-sm-2 control-label") %>
+                        <div class="col-sm-10">
+                            <input type="text" name="data[date]" id="data_date">
+                        </div>
+                    </div>
+
+                    <div class="form-group form-group-sm">
+                        <%= label_tag(:data_ref_type, "Type", class: "col-sm-2 control-label") %>
+                        <div class="col-sm-4">
+                            <%= select('data', 'ref_type', Reference.ref_type_options )%>
+                        </div>
+                    </div>
+
+                    <div class="form-group form-group-sm">
+                        <%= label_tag(:data_excerpt, "Excerpt", class: "col-sm-2 control-label") %>
+                        <div class="col-sm-10">
+                            <%= text_area(:data, :excerpt, size: "40x8")  %>
+                        </div>
+                    </div>
+                    
+                <% end %>
+            </div>
+            
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <input class="btn btn-primary" type="submit" value="Submit" form="reference-form">
+            </div>
+            
+        </div>
+    </div>
+</div>
+
+<%= javascript_tag do %>
+ $(document).ready(function(){
+     referenceModal();
+ });
+<% end %>

--- a/app/views/shared/_reference_new.html.erb
+++ b/app/views/shared/_reference_new.html.erb
@@ -3,8 +3,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h3 class="modal-title">Add a new reference</h3>
-                <h3><small><%= model.name %></small></h3>
+                <h4 class="modal-title">Add a new reference<br><small><%= model.name %></small></h4>
             </div>
             <div class="modal-body">
                 
@@ -62,7 +61,7 @@
                     <div class="form-group form-group-sm">
                         <%= label_tag(:data_excerpt, "Excerpt", class: "col-sm-2 control-label") %>
                         <div class="col-sm-10">
-                            <%= text_area(:data, :excerpt, size: "40x8")  %>
+                            <%= text_area(:data, :excerpt, size: "40x6")  %>
                         </div>
                     </div>
                     

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,8 +29,7 @@ Lilsis::Application.configure do
   config.assets.debug = true
 
   # Disable caching for development
-  config.cache_store = :memory_store
-  config.action_controller.perform_caching = true
+  # config.cache_store = :memory_store
 
   # In development, links in emails should point local
   config.action_mailer.default_url_options = { host: 'lilsis.local' }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,9 +19,10 @@ Lilsis::Application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
-  config.log_level = :debug
-
-  # Raise an error on page load if there are pending migrations
+  config.log_level = :info
+  config.log_formatter = ::Logger::Formatter.new
+  
+# Raise an error on page load if there are pending migrations
   config.active_record.migration_error = :page_load
 
   # Debug mode disables concatenation and preprocessing of assets.
@@ -29,7 +30,7 @@ Lilsis::Application.configure do
 
   # Disable caching for development
   config.cache_store = :memory_store
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # In development, links in emails should point local
   config.action_mailer.default_url_options = { host: 'lilsis.local' }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,6 +19,8 @@ Lilsis::Application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
+  config.log_level = :debug
+
   # Raise an error on page load if there are pending migrations
   config.active_record.migration_error = :page_load
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,8 @@ Lilsis::Application.routes.draw do
 
   resources :industries, only: [:show]
 
+  resources :relationships, only: [:show]
+
   get "/search" => "search#basic"
 
   get "/home/notes" => "home#notes"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,7 +208,7 @@ Lilsis::Application.routes.draw do
 
   resources :relationships, only: [:show]
 
-  resources :references, only: [:create, :destory]
+  resources :references, only: [:create, :destroy]
 
   get "/search" => "search#basic"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,6 +208,8 @@ Lilsis::Application.routes.draw do
 
   resources :relationships, only: [:show]
 
+  resources :references, only: [:create, :destory]
+
   get "/search" => "search#basic"
 
   get "/home/notes" => "home#notes"

--- a/lib/relationship_details.rb
+++ b/lib/relationship_details.rb
@@ -22,7 +22,7 @@ class RelationshipDetails
     when 5
       donation
     when 6
-      transation
+      transaciton
     when 7
       lobbying
     when 8
@@ -52,12 +52,32 @@ class RelationshipDetails
   end
   
   def education
-  end
-
-  def family
+    add_field(:description1, 'Type')
+      .add_field(:start_date, 'Start Date')
+      .add_field(:end_date, 'End Date')
+      .add_field(:degree, 'Degree')
+      .add_field(:education_field, 'Field')
+      .add_field(:is_dropout, 'Is Dropout', @@bool)
+      .add_field(:notes, 'Notes')
   end
 
   def membership
+    title
+      .add_field(:start_date, 'Start Date')
+      .add_field(:end_date, 'End Date')
+      .add_field(:is_current, 'Is Current', @@bool)
+      .add_field(:membership_dues, 'Dues')
+      .add_field(:notes, 'Notes')
+  end
+  
+  def family
+    description_field(:description1, @rel.entity)
+      description_field(:description2, @rel.related)
+      .add_field(:start_date, 'Start Date')
+      .add_field(:end_date, 'End Date')
+      .add_field(:is_current, 'Is Current', @@bool)
+      .add_field(:notes, 'Notes')
+
   end
 
   def donation
@@ -101,6 +121,17 @@ class RelationshipDetails
   def add_field(field, header, converter = lambda { |x| x.to_s })
     unless @rel.send(field).nil?
       @details << [ header, converter.call(@rel.send(field)) ]
+    end
+    self
+  end
+
+  
+  # For some categories, "description1" and "description2" are the
+  # the headers and the entity name are the fields
+  # input: symbol, <Entity>
+  def description_field(description, entity)
+    unless @rel.send(description).nil? or entity.name.blank?
+      @details << [ @rel.send(description).capitalize, entity.name ]
     end
     self
   end

--- a/lib/relationship_details.rb
+++ b/lib/relationship_details.rb
@@ -6,8 +6,39 @@ class RelationshipDetails
   def initialize(relationship)
     @rel = relationship
     @details = Array.new
+    calculate_details
   end
 
+  def calculate_details
+    case @rel.category_id
+    when 1
+      position
+    when 2
+      education
+    when 3
+      membership
+    when 4
+      family
+    when 5
+      donation
+    when 6
+      transation
+    when 7
+      lobbying
+    when 8
+      social
+    when 9
+      profession
+    when 10
+      ownership
+    when 11
+      hiearchy
+    when 12
+      generic
+    else
+    end
+  end
+  
   def position
     title
       .add_field(:start_date, 'Start Date')
@@ -17,8 +48,42 @@ class RelationshipDetails
       .add_field(:is_executive, 'Executive', @@bool)
       .add_field(:is_employee, 'Employee', @@bool)
       .add_field(:compensation, 'Compensation')
-      .add_fields(:notes, 'Notes')
+      .add_field(:notes, 'Notes')
   end
+  
+  def education
+  end
+
+  def family
+  end
+
+  def membership
+  end
+
+  def donation
+  end
+
+  def transaciton
+  end
+
+  def lobbying
+  end
+
+  def social
+  end
+
+  def profession
+  end
+
+  def ownership
+  end
+
+  def hiearchy
+  end
+
+  def generic
+  end
+
 
   def title
     return self unless [1,3,5,10].include? @rel.category_id 

--- a/lib/relationship_details.rb
+++ b/lib/relationship_details.rb
@@ -1,0 +1,43 @@
+class RelationshipDetails
+  attr_accessor :details
+
+  @@bool = lambda { |x| x ? 'yes' : 'no' }
+
+  def initialize(relationship)
+    @rel = relationship
+    @details = Array.new
+  end
+
+  def position
+    title
+      .add_field(:start_date, 'Start Date')
+      .add_field(:end_date, 'End Date')
+      .add_field(:is_current, 'Is Current', @@bool)
+      .add_field(:is_board, 'Board member', @@bool)
+      .add_field(:is_executive, 'Executive', @@bool)
+      .add_field(:is_employee, 'Employee', @@bool)
+      .add_field(:compensation, 'Compensation')
+      .add_fields(:notes, 'Notes')
+  end
+
+  def title
+    return self unless [1,3,5,10].include? @rel.category_id 
+    if @rel.description1.nil?
+      if @rel.category_id == 3
+        @details << ['Title', 'member']
+      end
+    else
+      @details << ['Title', @rel.description1 ]
+    end
+    self
+  end
+
+  # input: symbol, string, lambda
+  def add_field(field, header, converter = lambda { |x| x.to_s })
+    unless @rel.send(field).nil?
+      @details << [ header, converter.call(@rel.send(field)) ]
+    end
+    self
+  end
+
+end

--- a/lib/relationship_details.rb
+++ b/lib/relationship_details.rb
@@ -2,6 +2,9 @@ class RelationshipDetails
   attr_accessor :details
 
   @@bool = lambda { |x| x ? 'yes' : 'no' }
+  @@money = lambda { |x| ActiveSupport::NumberHelper::number_to_currency(x, precision: 0) }
+  @@percent = lambda { |x| x.to_s + '%' }
+  @@human_int = lambda { |x|  ActiveSupport::NumberHelper::number_to_human(x) }
 
   def initialize(relationship)
     @rel = relationship
@@ -22,7 +25,7 @@ class RelationshipDetails
     when 5
       donation
     when 6
-      transaciton
+      transaction
     when 7
       lobbying
     when 8
@@ -32,7 +35,7 @@ class RelationshipDetails
     when 10
       ownership
     when 11
-      hiearchy
+      hierarchy
     when 12
       generic
     else
@@ -47,7 +50,7 @@ class RelationshipDetails
       .add_field(:is_board, 'Board member', @@bool)
       .add_field(:is_executive, 'Executive', @@bool)
       .add_field(:is_employee, 'Employee', @@bool)
-      .add_field(:compensation, 'Compensation')
+      .add_field(:compensation, 'Compensation', @@money)
       .add_field(:notes, 'Notes')
   end
   
@@ -66,7 +69,7 @@ class RelationshipDetails
       .add_field(:start_date, 'Start Date')
       .add_field(:end_date, 'End Date')
       .add_field(:is_current, 'Is Current', @@bool)
-      .add_field(:membership_dues, 'Dues')
+      .add_field(:membership_dues, 'Dues', @@money)
       .add_field(:notes, 'Notes')
   end
   
@@ -81,27 +84,81 @@ class RelationshipDetails
   end
 
   def donation
+    add_field(:description1, 'Type')
+      .add_field(:start_date, 'Start Date')
+      .add_field(:end_date, 'End Date')
+      .add_field(:is_current, 'Is Current', @@bool)
+      .add_field(:amount, 'Amount', @@money)
+      .add_field(:filings, 'FEC Filings')
+      .add_field(:goods, 'Goods')
+      .add_field(:notes, 'Notes')
   end
 
-  def transaciton
+  def transaction
+    description_field(:description1, @rel.entity)
+      .description_field(:description2, @rel.related)
+      .add_field(:start_date, 'Start Date')
+      .add_field(:end_date, 'End Date')
+      .add_field(:is_current, 'Is Current', @@bool)
+      .add_field(:amount, 'Amount', @@money)
+      .add_field(:goods, 'Goods')
+      .add_field(:notes, 'Notes')
   end
 
   def lobbying
+    add_field(:description1, 'Type')
+      .add_field(:start_date, 'Start Date')
+      .add_field(:end_date, 'End Date')
+      .add_field(:is_current, 'Is Current', @@bool)
+      .add_field(:amount, 'Amount', @@money)
+      .add_field(:filings, 'LDA Filings')
+      .add_field(:notes, 'Notes')
   end
 
   def social
+    description_field(:description1, @rel.entity)
+      .description_field(:description2, @rel.related)
+      .add_field(:start_date, 'Start Date')
+      .add_field(:end_date, 'End Date')
+      .add_field(:is_current, 'Is Current', @@bool)
+      .add_field(:notes, 'Notes')
   end
 
   def profession
+    description_field(:description1, @rel.entity)
+      .description_field(:description2, @rel.related)
+      .add_field(:start_date, 'Start Date')
+      .add_field(:end_date, 'End Date')
+      .add_field(:is_current, 'Is Current', @@bool)
+      .add_field(:notes, 'Notes')
   end
 
   def ownership
+    title
+      .add_field(:start_date, 'Start Date')
+      .add_field(:end_date, 'End Date')
+      .add_field(:is_current, 'Is Current', @@bool)
+      .add_field(:percent_stake, 'Percent Stake', @@percent)
+      .add_field(:shares_owned, 'Shares', @@human_int)
+      .add_field(:notes, 'Notes')
   end
 
-  def hiearchy
+  def hierarchy
+    description_field(:description1, @rel.entity)
+      .description_field(:description2, @rel.related)
+      .add_field(:start_date, 'Start Date')
+      .add_field(:end_date, 'End Date')
+      .add_field(:is_current, 'Is Current', @@bool)
+      .add_field(:notes, 'Notes')
   end
 
   def generic
+    description_field(:description1, @rel.entity)
+      .description_field(:description2, @rel.related)
+      .add_field(:start_date, 'Start Date')
+      .add_field(:end_date, 'End Date')
+      .add_field(:is_current, 'Is Current', @@bool)
+      .add_field(:notes, 'Notes')
   end
 
 

--- a/spec/controllers/references_controller_spec.rb
+++ b/spec/controllers/references_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe ReferencesController, type: :controller do
+
+  before(:each) do 
+    DatabaseCleaner.start
+  end
+
+  after(:each) do 
+    DatabaseCleaner.clean
+  end
+
+  describe 'POST /reference' do 
+    login_user
+    
+    it 'creates a new reference' do 
+      expect {
+        post(:create, {object_id: 666,
+                       source: 'interesting.net',
+                       name: 'a website',
+                       object_model: "Relationship",
+                       ref_type: 1})
+      }.to change(Reference, :count).by(1)
+      
+      expect(Reference.last.object_model).to eql "Relationship"
+      expect(Reference.last.source).to eql "interesting.net"
+      expect(Reference.last.name).to eql "a website"
+      expect(Reference.last.object_id).to eql 666
+      expect(Reference.last.last_user_id). to eql SfGuardUser.last.id
+    end
+  end
+
+end

--- a/spec/controllers/references_controller_spec.rb
+++ b/spec/controllers/references_controller_spec.rb
@@ -10,24 +10,82 @@ describe ReferencesController, type: :controller do
     DatabaseCleaner.clean
   end
 
+  
+  describe 'auth' do 
+    it 'redirects to login if user is not logged in' do 
+      post(:create)
+      expect(response).to have_http_status(302)
+    end
+  end
+
   describe 'POST /reference' do 
     login_user
     
+    before(:all) do 
+      @post_data = {data: {
+                      object_id: 666,
+                      source: 'interesting.net',
+                      name: 'a website',
+                      object_model: "Relationship",
+                      ref_type: 1}
+                   }
+    end
+
     it 'creates a new reference' do 
-      expect {
-        post(:create, {object_id: 666,
-                       source: 'interesting.net',
-                       name: 'a website',
-                       object_model: "Relationship",
-                       ref_type: 1})
-      }.to change(Reference, :count).by(1)
+      allow(Relationship).to receive(:find) { double('relationship').as_null_object  }
       
+      expect { post(:create, @post_data) }.to change(Reference, :count).by(1)
+
       expect(Reference.last.object_model).to eql "Relationship"
       expect(Reference.last.source).to eql "interesting.net"
       expect(Reference.last.name).to eql "a website"
       expect(Reference.last.object_id).to eql 666
       expect(Reference.last.last_user_id). to eql SfGuardUser.last.id
+
+      expect(response).to have_http_status(:created)
     end
+
+    it 'updates updated_at field of the relationship' do 
+      rel = double("relationship")
+      expect(Relationship).to receive(:find).with(666).and_return(rel)
+      expect(rel).to receive(:touch)
+      post(:create, @post_data)
+    end
+
+    it 'returns json of errors if reference is not valid' do 
+      post(:create, {data: {
+                       object_id: 666,
+                       object_model: "Relationship",
+                       ref_type: 1}
+                    })
+      body = JSON.parse(response.body)
+
+      expect(response).to have_http_status(400)
+      expect(body['errors']['source']).to eql ["can't be blank"]
+    end
+
+  end
+
+  describe 'DELETE /reference' do 
+    login_user
+    
+    before(:all) do 
+     @ref = create(:ref, source: 'link', object_id: 1234) 
+    end
+    
+    it 'deletes a reference' do 
+      expect { 
+        delete :destroy, id: @ref 
+      }.to change(Reference, :count).by(-1)
+      
+      expect(response).to have_http_status(200)
+    end
+    
+    it 'bad_requests for bad ids' do 
+      delete :destroy, id: 8888
+      expect(response).to have_http_status(400)
+    end
+    
   end
 
 end

--- a/spec/controllers/references_controller_spec.rb
+++ b/spec/controllers/references_controller_spec.rb
@@ -27,13 +27,16 @@ describe ReferencesController, type: :controller do
                       source: 'interesting.net',
                       name: 'a website',
                       object_model: "Relationship",
+                      excerpt: "so and so said blah blah blah",
                       ref_type: 1}
                    }
     end
 
-    it 'creates a new reference' do 
+    before do 
       allow(Relationship).to receive(:find) { double('relationship').as_null_object  }
-      
+    end
+    
+    it 'creates a new reference' do 
       expect { post(:create, @post_data) }.to change(Reference, :count).by(1)
 
       expect(Reference.last.object_model).to eql "Relationship"
@@ -43,6 +46,37 @@ describe ReferencesController, type: :controller do
       expect(Reference.last.last_user_id). to eql SfGuardUser.last.id
 
       expect(response).to have_http_status(:created)
+    end
+
+    it 'creates a new ReferenceExcerpt if there is an excerpt' do 
+      expect { post(:create, @post_data) }.to change(ReferenceExcerpt, :count).by(1)
+      expect(ReferenceExcerpt.last.reference).to eql Reference.last
+      expect(Reference.last.excerpt).to eql "so and so said blah blah blah"
+    end
+
+    it 'does not create new ReferenceExcept if there is a blank excerpt' do 
+      expect { 
+        post(:create, {data: {object_id: 666,
+                              source: 'interesting.net',
+                              name: 'a website',
+                              object_model: "Relationship",
+                              excerpt: "",
+                              ref_type: 1 }}) 
+      }.to change(ReferenceExcerpt, :count).by(0)
+      
+      expect(Reference.last.excerpt).to be_nil
+    end
+
+    it 'does not create new ReferenceExcept if excerpt is not sent' do 
+      expect { 
+        post(:create, {data: {object_id: 666,
+                              source: 'interesting.net',
+                              name: 'a website',
+                              object_model: "Relationship",
+                              ref_type: 1 }}) 
+      }.to change(ReferenceExcerpt, :count).by(0)
+      
+      expect(Reference.last.excerpt).to be_nil
     end
 
     it 'updates updated_at field of the relationship' do 

--- a/spec/controllers/relationships_controller_spec.rb
+++ b/spec/controllers/relationships_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe RelationshipsController, type: :controller do
+
+  describe "GET #show" do
+    it "returns http success" do
+      get :show, {id: 1}
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/factories/education.rb
+++ b/spec/factories/education.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :education, class: Education do
+  end
+end

--- a/spec/factories/membership.rb
+++ b/spec/factories/membership.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :membership, class: Membership do
+  end
+end

--- a/spec/factories/ownership.rb
+++ b/spec/factories/ownership.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :ownership, class: Ownership do
+    end
+end

--- a/spec/factories/position.rb
+++ b/spec/factories/position.rb
@@ -1,4 +1,10 @@
 FactoryGirl.define do
   factory :position, class: Position do
+    is_board nil
+    is_executive nil
+    is_employee nil
+    compensation nil
+    boss_id nil
+    # relationship_id nil    
   end
 end

--- a/spec/factories/relationship.rb
+++ b/spec/factories/relationship.rb
@@ -16,6 +16,8 @@ FactoryGirl.define do
   end
 
   factory :relationship, class: Relationship do
+    association :entity, factory: :person, strategy: :build
+    association :related, factory: :mega_corp_llc, strategy: :build
   end
-  
+
 end

--- a/spec/helpers/references_helper_spec.rb
+++ b/spec/helpers/references_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ReferencesHelper. For example:
+#
+# describe ReferencesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ReferencesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/relationships_helper_spec.rb
+++ b/spec/helpers/relationships_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the RelationshipsHelper. For example:
+#
+# describe RelationshipsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe RelationshipsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/lib/relationship_details_spec.rb
+++ b/spec/lib/relationship_details_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'RelationshipDetails' do 
+
+  it 'initializes details as an empty array' do 
+      expect(RelationshipDetails.new(build(:relationship)).details).to eql []
+  end
+
+  describe 'title' do 
+    it 'returns self unless it is a position, member, donation, or ownership relationship' do 
+      expect(RelationshipDetails.new(build(:relationship, category_id: 2)).title.details).to eql []
+      expect(RelationshipDetails.new(build(:relationship, category_id: 4)).title.details).to eql []
+      expect(RelationshipDetails.new(build(:relationship, category_id: 6)).title.details).to eql []
+    end
+    
+    it 'returns member if d1 is nil and category_id = 3' do 
+      expect(RelationshipDetails.new(build(:relationship, category_id: 3)).title.details).to eql [ ['Title', 'member']]
+    end
+    
+  end
+  
+
+end

--- a/spec/lib/relationship_details_spec.rb
+++ b/spec/lib/relationship_details_spec.rb
@@ -14,10 +14,35 @@ describe 'RelationshipDetails' do
     end
     
     it 'returns member if d1 is nil and category_id = 3' do 
-      expect(RelationshipDetails.new(build(:relationship, category_id: 3)).title.details).to eql [ ['Title', 'member']]
+      expect(RelationshipDetails.new(build(:relationship, category_id: 3)).details).to eql [ ['Title', 'member']]
     end
     
   end
+
+  it 'returns details for position relationship' do 
+    rel = build(:relationship, category_id: 1, description1: 'boss', is_current: true, start_date: "1624")
+    rel.position = build(:position, is_board: false, compensation: 25)
+    expect(RelationshipDetails.new(rel).details).to eql [ ['Title', 'boss'], ['Start Date', '1624'], ['Is Current', 'yes'], ['Board member', 'no'], ['Compensation', '25'] ]
+  end
   
+  it 'returns details for education relationship' do 
+    rel = build(:relationship, category_id: 2, description1: 'Undergraduate', is_current: false)
+    rel.education = build(:education, degree_id: 6, is_dropout: true)
+    expect(RelationshipDetails.new(rel).details).to eql [ ['Type', 'Undergraduate'], ['Degree', "Bachelor's Degree"], ['Is Dropout', 'yes'] ]
+  end
+  
+  it 'returns details for membership relationship' do 
+    rel = build(:relationship, category_id: 3, start_date: '2000', end_date: '2001')
+    rel.membership = build(:membership, dues: 100)
+    expect(RelationshipDetails.new(rel).details).to eql [ ['Title', 'member'], ['Start Date', '2000'], ['End Date', '2001'], ['Dues', '100']]
+  end
+  
+  it 'returns details for family relationship' do 
+    rel = build(:relationship, category_id: 4, description1: 'Father', description2: 'Son')
+    rel.entity = build(:person, name: 'Vader')
+    rel.related = build(:person, name: 'Luke')
+    expect(RelationshipDetails.new(rel).details)
+      .to eql [ ['Father', 'Vader'], ['Son', 'Luke'] ]
+  end
 
 end

--- a/spec/lib/relationship_details_spec.rb
+++ b/spec/lib/relationship_details_spec.rb
@@ -22,7 +22,7 @@ describe 'RelationshipDetails' do
   it 'returns details for position relationship' do 
     rel = build(:relationship, category_id: 1, description1: 'boss', is_current: true, start_date: "1624")
     rel.position = build(:position, is_board: false, compensation: 25)
-    expect(RelationshipDetails.new(rel).details).to eql [ ['Title', 'boss'], ['Start Date', '1624'], ['Is Current', 'yes'], ['Board member', 'no'], ['Compensation', '25'] ]
+    expect(RelationshipDetails.new(rel).details).to eql [ ['Title', 'boss'], ['Start Date', '1624'], ['Is Current', 'yes'], ['Board member', 'no'], ['Compensation', '$25'] ]
   end
   
   it 'returns details for education relationship' do 
@@ -34,7 +34,7 @@ describe 'RelationshipDetails' do
   it 'returns details for membership relationship' do 
     rel = build(:relationship, category_id: 3, start_date: '2000', end_date: '2001')
     rel.membership = build(:membership, dues: 100)
-    expect(RelationshipDetails.new(rel).details).to eql [ ['Title', 'member'], ['Start Date', '2000'], ['End Date', '2001'], ['Dues', '100']]
+    expect(RelationshipDetails.new(rel).details).to eql [ ['Title', 'member'], ['Start Date', '2000'], ['End Date', '2001'], ['Dues', '$100']]
   end
   
   it 'returns details for family relationship' do 
@@ -43,6 +43,59 @@ describe 'RelationshipDetails' do
     rel.related = build(:person, name: 'Luke')
     expect(RelationshipDetails.new(rel).details)
       .to eql [ ['Father', 'Vader'], ['Son', 'Luke'] ]
+  end
+
+  it 'returns details for donation relationship' do 
+    rel = build(:relationship, category_id: 5, description1: 'Campaign Contribution', start_date: '1900', end_date: '2000', amount: 7000, filings: 2)
+    expect(RelationshipDetails.new(rel).details)
+      .to eql [ ['Type', 'Campaign Contribution'], ['Start Date', '1900'], ['End Date', '2000'], ['Amount', '$7,000'], ['FEC Filings', '2'] ]
+  end
+  
+  it 'returns details for transaction relationship' do 
+    rel = build(:relationship, category_id: 6, goods: 'jelly beans', is_current: true)
+    expect(RelationshipDetails.new(rel).details).to eql [ [ 'Is Current', 'yes'], ['Goods', 'jelly beans'] ]
+  end
+  
+  it 'returns details for lobbying relationship' do 
+    rel = build(:relationship, category_id: 7, amount: 10)
+    expect(RelationshipDetails.new(rel).details).to eql [ [ 'Amount', '$10' ] ]
+  end
+  
+  it 'returns details for social relationship' do 
+    rel = build(:relationship, category_id: 8, description1: 'Friend', description2: 'Best Friend')
+    rel.entity = build(:person, name: 'Alice')
+    rel.related = build(:person, name: 'Bob')
+    expect(RelationshipDetails.new(rel).details)
+      .to eql [ [ 'Friend', 'Alice' ], ['Best friend', 'Bob'] ]
+  end
+
+  it 'returns details for professional relationships' do 
+    rel = build(:relationship, category_id: 9, description1: 'X', description2: 'Y', is_current: true)
+    rel.entity = build(:person, name: 'Alice')
+    rel.related = build(:person, name: 'Bob')
+    expect(RelationshipDetails.new(rel).details)
+      .to eql [ [ 'X', 'Alice' ], ['Y', 'Bob'], ['Is Current', 'yes'] ]
+  end
+
+  it 'returns details for ownership relationships' do
+    rel = build(:relationship, category_id: 10, description1: 'owner')
+    rel.ownership = build(:ownership, percent_stake: 20, shares: 1500)
+    expect(RelationshipDetails.new(rel).details)
+      .to eql [ ['Title', 'owner'], ['Percent Stake', '20%'], ['Shares', '1.5 Thousand']]
+  end
+  
+  it 'returns details for hierarchy relationship' do
+    rel = build(:relationship, category_id: 11, description1: 'In charge')
+    rel.entity = build(:person, name: 'Queen')
+    expect(RelationshipDetails.new(rel).details)
+      .to eql [ ['In charge', 'Queen']]
+  end
+
+  it 'returns details for generic relationship' do
+    rel = build(:relationship, category_id: 12, description1: 'X', notes: '1234')
+    rel.entity = build(:person, name: 'Y')
+    expect(RelationshipDetails.new(rel).details)
+      .to eql [ ['X', 'Y'], ['Notes', '1234']]
   end
 
 end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -123,4 +123,28 @@ describe Relationship, type: :model do
 
   end
 
+  describe 'RelationshipDisplay' do
+    describe '#name' do
+      it 'generates correct title for position relationship' do 
+        rel = build(:relationship, category_id: 1, description1: 'boss')
+        rel.position = build(:position, is_board: false)
+        expect(rel.name).to eql "Position: Human Being, mega corp LLC"
+      end
+    end
+  end
+
+  describe 'legacy_url' do 
+    before(:all) do 
+      @rel = build(:relationship, id: 1000)
+    end
+    
+    it 'generates correct url' do 
+      expect(@rel.legacy_url).to eql "/relationship/view/id/1000" 
+    end
+    
+    it 'generates correct url with action' do 
+      expect(@rel.legacy_url('edit')).to eql "/relationship/edit/id/1000" 
+    end
+  end
+
 end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -150,7 +150,7 @@ describe Relationship, type: :model do
       it 'Position' do 
         rel = build(:relationship, category_id: 1, description1: 'boss', is_current: true)
         rel.position = build(:position, is_board: false)
-        expect(rel.details).to eql [ ['Title', 'boss'], ['Is current', 'yes'], ['Board member', 'no'] ]
+        expect(rel.details).to eql [ ['Title', 'boss'], ['Is Current', 'yes'], ['Board member', 'no'] ]
       end
       
     end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -123,13 +123,11 @@ describe Relationship, type: :model do
 
   end
 
-  describe 'RelationshipDisplay' do
-    describe '#name' do
-      it 'generates correct title for position relationship' do 
-        rel = build(:relationship, category_id: 1, description1: 'boss')
-        rel.position = build(:position, is_board: false)
-        expect(rel.name).to eql "Position: Human Being, mega corp LLC"
-      end
+  describe '#name' do
+    it 'generates correct title for position relationship' do 
+      rel = build(:relationship, category_id: 1, description1: 'boss')
+      rel.position = build(:position, is_board: false)
+      expect(rel.name).to eql "Position: Human Being, mega corp LLC"
     end
   end
 
@@ -146,5 +144,19 @@ describe Relationship, type: :model do
       expect(@rel.legacy_url('edit')).to eql "/relationship/edit/id/1000" 
     end
   end
+
+  describe '#details' do 
+    describe 'it returns [ [field, value] ] for each Relationship type' do 
+      it 'Position' do 
+        rel = build(:relationship, category_id: 1, description1: 'boss', is_current: true)
+        rel.position = build(:position, is_board: false)
+        expect(rel.details).to eql [ ['Title', 'boss'], ['Is current', 'yes'], ['Board member', 'no'] ]
+      end
+      
+    end
+    
+    
+  end
+  
 
 end

--- a/spec/views/entities/match_donations.html.erb_spec.rb
+++ b/spec/views/entities/match_donations.html.erb_spec.rb
@@ -29,7 +29,7 @@ describe 'entities/match_donations.html.erb' do
     
     it 'has actions' do 
       expect(rendered).to have_css '#entity-edited-history'
-      expect(rendered).to have_css '#entity-actions a', :count => 3
+      expect(rendered).to have_css '#actions a', :count => 3
     end
   
     it 'has table' do 

--- a/spec/views/entities/political.html.erb_spec.rb
+++ b/spec/views/entities/political.html.erb_spec.rb
@@ -27,7 +27,7 @@ describe 'entities/political.html.erb' do
 
     it 'has actions' do 
       expect(rendered).to have_css '#entity-edited-history'
-      expect(rendered).to have_css '#entity-actions a', :count => 3
+      expect(rendered).to have_css '#actions a', :count => 3
     end
 
     it 'has tabs' do 
@@ -48,7 +48,7 @@ describe 'entities/political.html.erb' do
 
     it 'has pie info div with spans' do
       expect(rendered).to have_css '#pie-info', :count => 1
-      expect(rendered).to have_css '#pie-info p span', :count => 4
+      expect(rendered).to have_css '#pie-info p span', :count => 6
     end
 
   end

--- a/spec/views/entities/show.html.erb_spec.rb
+++ b/spec/views/entities/show.html.erb_spec.rb
@@ -56,11 +56,11 @@ describe 'entities/show.html.erb' do
         describe 'buttons' do 
           
           it 'has action div' do
-            expect(rendered).to have_css('#entity-actions')
+            expect(rendered).to have_css('#actions')
           end
 
           it 'has 3 links' do 
-            expect(rendered).to have_css('#entity-actions a', :count => 3)
+            expect(rendered).to have_css('#actions a', :count => 3)
           end
 
           it 'has relationship link' do
@@ -117,7 +117,7 @@ describe 'entities/show.html.erb' do
       end
       
       it 'has 4 links' do
-        expect(rendered).to have_css('#entity-actions a', :count => 4)
+        expect(rendered).to have_css('#actions a', :count => 4)
       end
       
       it 'renders remove button' do
@@ -147,7 +147,7 @@ describe 'entities/show.html.erb' do
       end
 
       it 'has 5 links' do
-        expect(rendered).to have_css('#entity-actions a', :count => 5)
+        expect(rendered).to have_css('#actions a', :count => 5)
       end
 
       it 'renders match donations button' do
@@ -174,7 +174,7 @@ describe 'entities/show.html.erb' do
       end
 
       it 'has 6 links' do
-        expect(rendered).to have_css('#entity-actions a', :count => 6)
+        expect(rendered).to have_css('#actions a', :count => 6)
       end
     end
 

--- a/spec/views/relationships/show.html.erb_spec.rb
+++ b/spec/views/relationships/show.html.erb_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe "relationships/show.html.erb", type: :view do
+  before(:all) do
+    DatabaseCleaner.start
+  end
+
+  after(:all) do 
+    DatabaseCleaner.clean
+  end
+
+  describe 'layout' do 
+
+    before do
+      render
+    end
+
+  end
+  
+end

--- a/spec/views/relationships/show.html.erb_spec.rb
+++ b/spec/views/relationships/show.html.erb_spec.rb
@@ -1,8 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe "relationships/show.html.erb", type: :view do
+describe "relationships/show.html.erb", type: :view do
+
+  def css(*args)
+    expect(rendered).to have_css(*args)
+  end
+
   before(:all) do
-    # DatabaseCleaner.start
     @sf_user = build(:sf_guard_user)
     @user = build(:user)
     @sf_user.user = @user
@@ -11,24 +15,81 @@ RSpec.describe "relationships/show.html.erb", type: :view do
     @rel.last_user = @sf_user
   end
 
-  after(:all) do 
-    # DatabaseCleaner.clean
-  end
-
   describe 'layout' do 
 
     before do
       assign(:relationship, @rel)
+      expect(@rel).to receive(:source_links).and_return([])
       render
     end
 
     it 'has title' do 
-      expect(rendered).to have_css 'h1', :text => "Position: Human Being, mega corp LLC"
+      css 'h1', :text => "Position: Human Being, mega corp LLC"
+    end
+
+    it 'has subtitle' do 
+      css 'h4 a', :count => 2
     end
     
+    it 'has source links table' do 
+      css '#source-links-table', :count => 1
+    end
+
     describe 'actions' do 
-      
-      
+      it 'has actions div' do 
+        css '#actions'
+      end
+
+      it 'has edited history' do 
+        css '#entity-edited-history'
+        css 'a', :text => 'user'
+      end
+    end
+
+  end
+
+
+  describe 'Add Reference Modal' do 
+
+    before do
+      @current_user = double('user')
+      allow(@current_user).to receive(:has_legacy_permission).and_return(true)
+      assign(:relationship, @rel)
+      assign(:current_user, @current_user)
+      allow(view).to receive(:user_signed_in?).and_return(true)
+      render
+    end
+    
+    it 'has modal and form' do 
+      css '#add-reference-modal'
+      css 'form', :count => 1
+    end
+
+    it 'has hidden inputs' do 
+      css 'input[value="Relationship"]', :count => 1
+      css 'input#data_object_id', :count => 1
+    end
+
+    it 'has url field' do 
+      css 'input[type="url"]', :count => 1
+    end
+
+    it 'has 2 text fields' do 
+      css 'input[type="text"]', :count => 2
+    end
+
+    it 'has select field with 3 options' do 
+      css 'select', :count => 1
+      css 'option', :count => 3
+    end
+    
+    it 'has text area' do 
+      css 'textarea', :count => 1
+    end
+
+    it 'has close and submit buttons' do 
+      css 'button', :text => 'Close'
+      css 'input[type="submit"]', :count => 1
     end
     
     

--- a/spec/views/relationships/show.html.erb_spec.rb
+++ b/spec/views/relationships/show.html.erb_spec.rb
@@ -2,19 +2,36 @@ require 'rails_helper'
 
 RSpec.describe "relationships/show.html.erb", type: :view do
   before(:all) do
-    DatabaseCleaner.start
+    # DatabaseCleaner.start
+    @sf_user = build(:sf_guard_user)
+    @user = build(:user)
+    @sf_user.user = @user
+    @rel = build(:relationship, category_id: 1, description1: 'boss', id: 123, updated_at: Time.now)
+    @rel.position = build(:position, is_board: false)
+    @rel.last_user = @sf_user
   end
 
   after(:all) do 
-    DatabaseCleaner.clean
+    # DatabaseCleaner.clean
   end
 
   describe 'layout' do 
 
     before do
+      assign(:relationship, @rel)
       render
     end
 
+    it 'has title' do 
+      expect(rendered).to have_css 'h1', :text => "Position: Human Being, mega corp LLC"
+    end
+    
+    describe 'actions' do 
+      
+      
+    end
+    
+    
   end
   
 end


### PR DESCRIPTION
This adds the view of relationship page at `/relationships/id`

Two new controllers; Relationship and Reference

It also adds modal to create new references to a relationship. This modal can be re-used for other pages as well.

it includes a new gem -- bootstrap-datepicker-rails -- that provides a bootstrap datepicker.

Adds missing RelationshipExcerpt model and puts helper css classes in helpers.css.
