### PR TITLE
Use updated embedded oligrapher

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -78,7 +78,6 @@ class MapsController < ApplicationController
   end
 
   def embedded_v2
-    @dev_version = true
     @header_pct = embedded_params.fetch(:header_pct, EMBEDDED_HEADER_PCT)
     @annotation_pct = embedded_params.fetch(:annotation_pct, EMBEDDED_ANNOTATION_PCT)
     response.headers.delete('X-Frame-Options')

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -10,7 +10,7 @@ class MapsController < ApplicationController
   protect_from_forgery except: [:create, :clone]
 
   # defaults for embedded oligrapher
-  EMBEDDED_HEADER_PCT = 10
+  EMBEDDED_HEADER_PCT = 8
   EMBEDDED_ANNOTATION_PCT = 28
 
   def index
@@ -77,7 +77,7 @@ class MapsController < ApplicationController
     @berman_map = NetworkMap.find(137)
   end
 
-  def dev_embedded
+  def embedded_v2
     @dev_version = true
     @header_pct = embedded_params.fetch(:header_pct, EMBEDDED_HEADER_PCT)
     @annotation_pct = embedded_params.fetch(:annotation_pct, EMBEDDED_ANNOTATION_PCT)

--- a/app/views/maps/embedded_v2.html.erb
+++ b/app/views/maps/embedded_v2.html.erb
@@ -4,6 +4,7 @@
     
     <% if @dev_version %>
 	<script type="text/javascript" src="/js/oligrapher-dev.js"></script>
+	<script type="text/javascript" src="/js/LsDataSource.js"></script>
     <% else %>
 	<%= javascript_include_tag "oligrapher" %>
     <% end %>

--- a/app/views/maps/embedded_v2.html.erb
+++ b/app/views/maps/embedded_v2.html.erb
@@ -2,12 +2,7 @@
 
 <%= cache_if !user_signed_in?, [ 'embedded', @map ] do %>
     
-    <% if @dev_version %>
-	<script type="text/javascript" src="/js/oligrapher-dev.js"></script>
-	<script type="text/javascript" src="/js/LsDataSource.js"></script>
-    <% else %>
-	<%= javascript_include_tag "oligrapher" %>
-    <% end %>
+    <%= javascript_include_tag "oligrapher" %>
     
     <% content_for(:page_title, raw(@map.name)) %>
     <% content_for(:facebook_title, @map.name) %>

--- a/app/views/maps/story_map.html.erb
+++ b/app/views/maps/story_map.html.erb
@@ -9,6 +9,7 @@
 <%= render 'shared/facebook_sdk' %>
 <% if @dev_version %>
     <script type="text/javascript" src="/js/oligrapher-dev.js"></script>
+    <script type="text/javascript" src="/js/LsDataSource.js"></script>
 <% else %>
     <%= javascript_include_tag "oligrapher" %>
 <% end %>

--- a/app/views/maps/story_map.html.erb
+++ b/app/views/maps/story_map.html.erb
@@ -32,7 +32,7 @@
 <div id="embed-code">
     Width <input type="text" id="embed-width" value="550">&nbsp;&nbsp;
     Height <input type="text" id="embed-height" value="400">&nbsp;&nbsp;
-    <textarea><iframe height="600" width="600" scrolling="no" style="border: 0px; overflow: hidden;" src="<%= embedded_map_url(@map) %>"></iframe><div style="padding: 5px;"><%= link_to('view this map on LittleSis', map_url(@map)) %></div></textarea>
+    <textarea><iframe height="600" width="700" scrolling="no" style="border: 0px; overflow: hidden;" src="<%= embedded_v2_map_url(@map) %>"></iframe></textarea>
 </div>
 
 <% if @editable %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,7 +190,7 @@ Lilsis::Application.routes.draw do
       get 'map_json'
       get 'dev'
       get 'edit/dev' => 'maps#dev_edit'
-      get 'embedded/dev' => 'maps#dev_embedded'
+      get 'embedded/v2' => 'maps#embedded_v2'
     end
 
     collection do

--- a/spec/controllers/maps_controllers_spec.rb
+++ b/spec/controllers/maps_controllers_spec.rb
@@ -16,7 +16,7 @@ describe MapsController, type: :controller do
     it { should route(:post, '/maps/1706-colorado-s-terrible-ten/clone').to(action: :clone, id: '1706-colorado-s-terrible-ten') }
     it { should route(:delete, '/maps/1706-colorado-s-terrible-ten').to(action: :destroy, id: '1706-colorado-s-terrible-ten') }
     it { should route(:get, '/maps/1706-colorado-s-terrible-ten/embedded').to(action: :embedded, id: '1706-colorado-s-terrible-ten') }
-    it { should route(:get, '/maps/1706-colorado-s-terrible-ten/embedded/dev').to(action: :dev_embedded, id: '1706-colorado-s-terrible-ten') }
+    it { should route(:get, '/maps/1706-colorado-s-terrible-ten/embedded/v2').to(action: :embedded_v2, id: '1706-colorado-s-terrible-ten') }
     it { should route(:get, '/maps/1706-colorado-s-terrible-ten/edit').to(action: :edit, id: '1706-colorado-s-terrible-ten') }
     it { should route(:get, '/maps/1706-colorado-s-terrible-ten/dev').to(action: :dev, id: '1706-colorado-s-terrible-ten') }
     it { should route(:get, '/maps/1706-colorado-s-terrible-ten/edit/dev').to(action: :dev_edit, id: '1706-colorado-s-terrible-ten') }


### PR DESCRIPTION
Updates rails code to use the new embedded oligrapher.

The old route is still available at ``` /embedded ```

The new page is at ``` /embedded/v2 ```